### PR TITLE
Mjulian/add zentyal distgroup

### DIFF
--- a/SoObjects/SOGo/SOGoGroup.m
+++ b/SoObjects/SOGo/SOGoGroup.m
@@ -198,7 +198,6 @@
       if ([classes containsObject: @"group"] ||
 	  [classes containsObject: @"groupofnames"] ||
 	  [classes containsObject: @"groupofuniquenames"] ||
-	  [classes containsObject: @"zentyaldistributiongroup"] ||
 	  [classes containsObject: @"posixgroup"])
 	{
 	  o = [[self alloc] initWithIdentifier: theValue


### PR DESCRIPTION
At the sogo UI, zentyal distribution groups got from the LDAP will be shown with the group icon as, this branch adds zentyaldistributiongroup class to the internal "isGroup" checking.
