### PR TITLE
Fixed load images button not working case

### DIFF
--- a/UI/WebServerResources/MailerUI.js
+++ b/UI/WebServerResources/MailerUI.js
@@ -1567,6 +1567,12 @@ function onMessageEditDraft(event) {
     return openMessageWindowsForSelection("edit", true);
 }
 
+function onMessageAnchorClick(event) {
+    if (this.href)
+        window.open(this.href);
+    preventDefault(event);
+}
+
 function onMessageLoadImages(event) {
     loadRemoteImages();
     Event.stop(event);


### PR DESCRIPTION
- When a HTML email had a image and a link, the "load images" button
  was not working. There was a missing function which has been added
  from the same file, but from a pre-fatal-UI-merge commit
