### PR TITLE
Mjulian/hide imap accouns credentials

### DIFF
--- a/UI/WebServerResources/UIxPreferences.css
+++ b/UI/WebServerResources/UIxPreferences.css
@@ -127,7 +127,7 @@ P.infoMessage#passwordError
 { position: absolute;
   overflow: auto;
   bottom: 30px;
-  left: 140px;
+//  left: 140px;
   padding: 0px;
   right: 5px; }
 
@@ -139,7 +139,12 @@ P.infoMessage#passwordError
   left: 5px;
   width: 130px;
   border-top: 1px solid #9b9b9b;
+  display: none;
 position: relative;}
+
+fieldset#accountInfo {
+    display: none;
+}
 
 #mailAccountsList
 { position: absolute;


### PR DESCRIPTION
This pull request hides some information from the IMAP accounts tab at the preferences section.
Initialy sogo was showing on the left a box with a (only one) email addresses configured. This has been hidden.
Also the credentials (server:port, username, password) where shown in that section. This info has also been hidden as it is not interesting for the user in any way.
