### PR TITLE
Jgarcia/register thread

### DIFF
--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -59,7 +59,7 @@ static BOOL initialization_done = NO;
 #define NS_CURRENT_THREAD_REGISTER() \
     BOOL __nsrct_thread_registered = GSRegisterCurrentThread(); \
     if (!initialization_done) { \
-        DEBUG(0, ("[SOGo: %s:%d] You should call sogo_backend_init() first. Current thread: %p, pid: %d\n", \
+        DEBUG(5, ("[SOGo: %s:%d] You should call sogo_backend_init() first. Current thread: %p, pid: %d\n", \
 		  __FUNCTION__, __LINE__, GSCurrentThread(), getpid())); \
     }
 #define NS_CURRENT_THREAD_TRY_UNREGISTER() \


### PR DESCRIPTION
### Before

We were checking that current thread was registered, that meant sogo_backend_init was called (because we were calling GSRegisterCurrentThread there)
### Now

We are checking that sogo_backend_init is called before others functions. If sogo_backend_init has not been called we show a warning and we'll unregister current thread at the end of the function.
