### PR TITLE
Compose new mail windows is now larger

### DIFF
--- a/UI/WebServerResources/generic.js
+++ b/UI/WebServerResources/generic.js
@@ -304,7 +304,7 @@ function openMailComposeWindow(url, wId) {
             parentWindow = window.opener;
 
         var w = parentWindow.open(url, wId,
-                                  "width=680,height=520,resizable=1,scrollbars=1,toolbar=0,"
+                                  "width=900,height=620,resizable=1,scrollbars=1,toolbar=0,"
                                   + "location=0,directories=0,status=0,menubar=0"
                                   + ",copyhistory=0");
 


### PR DESCRIPTION
When composing a new mail in HTML mode, the popup window opened was too short and narrow. Changed those default values so the body text area is now larger.
