### PR TITLE
Cached usercontext objects update indexing_context

### DIFF
--- a/OpenChange/MAPIStoreMapping.h
+++ b/OpenChange/MAPIStoreMapping.h
@@ -42,6 +42,7 @@
 - (id) initForUsername: (NSString *) username
           withIndexing: (struct indexing_context *) indexing;
 
+- (void) updateIndexing: (struct indexing_context *) indexing;
 
 - (void) increaseUseCount;
 - (void) decreaseUseCount;

--- a/OpenChange/MAPIStoreMapping.m
+++ b/OpenChange/MAPIStoreMapping.m
@@ -119,6 +119,11 @@ MAPIStoreMappingKeyFromId (uint64_t idNbr)
   return self;
 }
 
+- (void) updateIndexing: (struct indexing_context *) newIndexing
+{
+    indexing = newIndexing;
+}
+
 - (void) dealloc
 {
   [username release];

--- a/OpenChange/MAPIStoreUserContext.h
+++ b/OpenChange/MAPIStoreUserContext.h
@@ -68,6 +68,8 @@
 - (id) initWithUsername: (NSString *) newUsername
          andTDBIndexing: (struct indexing_context *) indexing;
 
+- (void) updateIndexing: (struct indexing_context *) indexing;
+
 - (NSString *) username;
 - (SOGoUser *) sogoUser;
 

--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -65,7 +65,14 @@ static NSMapTable *contextsTable = nil;
   id userContext;
 
   userContext = [contextsTable objectForKey: username];
-  if (!userContext)
+  if (userContext)
+    {
+      // The indexing_context used when this user context was created
+      // could had been freed, so we have to update it and use the one
+      // that we receive as parameter (which is a valid one for sure).
+      [userContext updateIndexing: indexing];
+    }
+  else
     {
       userContext = [[self alloc] initWithUsername: username
                                     andTDBIndexing: indexing];
@@ -74,6 +81,11 @@ static NSMapTable *contextsTable = nil;
     }
 
   return userContext;
+}
+
+- (void) updateIndexing: (struct indexing_context *) indexing
+{
+    [mapping updateIndexing: indexing];
 }
 
 - (id) init


### PR DESCRIPTION
Instead of use always the one given on initialization.

Detected with weird crash reports (a couple that I know of: 199, 1898) where the sql queries where crashing because bad MYSQL \* pointer was used, because sogo was using an indexing_context already freed so it was garbage.
