### PR TITLE
RTF Parser: fix crash parsing font table

### DIFF
--- a/OpenChange/RTFHandler.m
+++ b/OpenChange/RTFHandler.m
@@ -412,16 +412,17 @@ const unsigned short ansicpg874[256] = {
 - (const char *) parseControlWord: (unsigned int *) len
 {
   const char *start, *end;
-  
+
   start = ADVANCE;
-  
-  while (isalnum(*_bytes) || *_bytes == '-')
+
+  while (isalnum(*_bytes) || *_bytes == '-' || isspace(*_bytes))
     {
       ADVANCE;
     }
   end = _bytes;
-  
+
   *len = end-start-1;
+
   return start+1;
 }
 


### PR DESCRIPTION
Zentyal crashreports related with this: 1628, 1654, 1849, 2089, 2090, 2125, 2139 from the manually triaged subset, probably it'll be a lot more. c&p commit message

---

oc-rtf: control words can also have a space before next tag

This was causing to parse a single space as an empty control
word with length 0, which was the source of several crashes.

Example:

```
\f0\fbidi \fcharset0
 --------^
```

font index is 0, font family is bidi but when parsing charset we were
assuming control word was '' instead of 'charset0'.

This only fixes the crashes, the parseFontTable function works quite
awful right now.
