### PR TITLE
Disable optimizations on zentyal-3.2 build branch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ include /usr/share/GNUstep/Makefiles/common.make
 
 config.make: configure
 	dh_testdir
-	./configure --prefix=$(GNUSTEP_SYSTEM_ROOT) $(SAML2_CONFIG)
+	./configure --prefix=$(GNUSTEP_SYSTEM_ROOT) $(SAML2_CONFIG) --enable-debug
 
 #Architecture
 build: build-arch
@@ -27,11 +27,11 @@ build: build-arch
 build-arch: build-arch-stamp
 build-arch-stamp:  config.make
 #	 Add here commands to compile the arch part of the package.
-	$(MAKE)
+	CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE)
 	if pkg-config --atleast-version=1.0 libmapi; \
-	then (cd OpenChange; $(MAKE));  \
+	then (cd OpenChange; CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE));  \
 	fi
-	(cd ActiveSync && $(MAKE))
+	(cd ActiveSync && CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE))
 	touch $@
 
 clean:
@@ -69,11 +69,11 @@ install-arch: build-arch
 	dh_prep
 #	dh_installdirs -s
 
-	$(MAKE) PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/samba4/lib/pkgconfig" DESTDIR=$(DESTDIR) GNUSTEP_INSTALLATION_DOMAIN=SYSTEM install
+	CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE) PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/samba4/lib/pkgconfig" DESTDIR=$(DESTDIR) GNUSTEP_INSTALLATION_DOMAIN=SYSTEM install
 	if pkg-config --atleast-version=1.0 libmapi; \
 	then \
 	  (cd OpenChange; \
-	   $(MAKE) \
+	   CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE) \
 	       DESTDIR=$(DESTDIR) \
 	       GNUSTEP_INSTALLATION_DOMAIN=SYSTEM \
 	     install); \
@@ -82,7 +82,7 @@ install-arch: build-arch
 	  mv -f $(DESTDIR)/opt/samba4/lib/mapistore_backends/libMAPIStoreSOGo.so.1.0.0 \
 	           $(DESTDIR)/opt/samba4/lib/mapistore_backends/SOGo.so; \
 	fi
-	(cd ActiveSync; $(MAKE) DESTDIR=$(DESTDIR) GNUSTEP_INSTALLATION_DOMAIN=SYSTEM install)
+	(cd ActiveSync; CFLAGS="$(CFLAGS) -O0 " OBJCFLAGS="$(CFLAGS) -O0 " $(MAKE) DESTDIR=$(DESTDIR) GNUSTEP_INSTALLATION_DOMAIN=SYSTEM install)
 
 	install -D -m 644 Scripts/sogo-default debian/tmp/etc/default/sogo
 	install -D -m 644 debian/sogo.overrides debian/tmp/usr/share/lintian/overrides/sogo


### PR DESCRIPTION
```
(gdb) p pull_request->body
$1 = <optimized out>
```

:no_bicycles: 
