### PR TITLE
oc-mailfolder: Avoid setting seen flag on preloading message bodies

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1277,9 +1277,8 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
   NSUInteger count, max;
   NSString *messageKey, *messageUid, *bodyPartKey;
   NGImap4Client *client;
-  NSArray *fetch, *flags;
+  NSArray *fetch;
   NSData *bodyContent;
-  BOOL unseen;
   NSMutableArray *unseenUIDs;
 
   if (tableType == MAPISTORE_MESSAGE_TABLE)
@@ -1291,6 +1290,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
         {
           bodyPartKeys = [NSMutableSet setWithCapacity: max];
 
+          unseenUIDs = [NSMutableArray arrayWithCapacity: max];
           keyAssoc = [NSMutableDictionary dictionaryWithCapacity: max];
           for (count = 0; count < max; count++)
             {
@@ -1304,30 +1304,21 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                       [bodyPartKeys addObject: bodyPartKey];
                       messageUid = [self messageUIDFromMessageKey: messageKey];
                       [keyAssoc setObject: bodyPartKey forKey: messageUid];
+                      /* Fetch flags to remove seen flag if required,
+                         as fetching a message body set the seen flag.
+                         We are not using body.peek[] as
+                         bodyContentPartKey explicitly avoids it.
+                      */
+                      if (![message read])
+                        {
+                          [unseenUIDs addObject: messageUid];
+                        }
                     }
                 }
             }
       
           client = [[(SOGoMailFolder *) sogoObject imap4Connection] client];
           [client select: [sogoObject absoluteImap4Name]];
-
-          /* Fetch flags to remove seen flag if required,
-             as fetching a message body set the seen flag */
-          response = [client fetchUids: [keyAssoc allKeys]
-                                 parts: [NSArray arrayWithObjects: @"flags", nil]];
-          fetch = [response objectForKey: @"fetch"];
-          max = [fetch count];
-          unseenUIDs = [NSMutableArray arrayWithCapacity: max];
-          for (count = 0; count < max; count++)
-            {
-              response = [fetch objectAtIndex: count];
-              messageUid = [[response objectForKey: @"uid"] stringValue];
-              flags = [response objectForKey: @"flags"];
-              unseen = [flags indexOfObject: @"seen"] == NSNotFound;
-              if (unseen) {
-                [unseenUIDs addObject: messageUid];
-              }
-            }
 
           response = [client fetchUids: [keyAssoc allKeys]
                              parts: [bodyPartKeys allObjects]];
@@ -1351,7 +1342,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                 }
             }
 
-          // Restore unseen state once the body has been fetched
+          /* Restore unseen state once the body has been fetched */
           if ([unseenUIDs count] > 0)
             {
               response = [client storeFlags: [NSArray arrayWithObjects: @"seen", nil]

--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -73,6 +73,7 @@
 /* batch-mode helpers */
 - (NSString *) bodyContentPartKey;
 - (void) setBodyContentFromRawData: (NSData *) rawContent;
+- (BOOL) read; /* Unseen from sogoObject */
 
 @end
 

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1599,4 +1599,12 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
     }
 }
 
+- (BOOL) read
+{
+  if (!headerSetup)
+    [self _fetchHeaderData];
+
+  return [sogoObject read];
+}
+
 @end


### PR DESCRIPTION
Fetching a body[text] property using IMAP makes IMAP server set seen flag.

This commit fetches the flag beforehand to restore the previous state
once the body has been fetched.
