### PR TITLE
Fix compilation when samba file is not others readable

### DIFF
--- a/OpenChange/GNUmakefile
+++ b/OpenChange/GNUmakefile
@@ -31,7 +31,7 @@ endif
 all::
 	@echo " Python executable: ${PYTHON}"
 
-SAMBA_PRIVATE_DIR = $(shell $(PYTHON) ./samba-get-config.py "private dir")
+SAMBA_PRIVATE_DIR = $(shell $(PYTHON) ./samba-get-config.py 'private dir' || echo /var/lib/samba/private)
 
 $(SOGOBACKEND)_PRINCIPAL_CLASS = MAPIApplication
 


### PR DESCRIPTION
This happens when any smb.conf or included file is not others readable,
thus we are fallbacking to the default installation path.

Any other to fallback is welcomed.
