### PR TITLE
Fix contacts cached that don't belong to our domain

### DIFF
--- a/SoObjects/SOGo/NSString+Utilities.m
+++ b/SoObjects/SOGo/NSString+Utilities.m
@@ -548,9 +548,9 @@ static NSCharacterSet *controlCharSet = nil;
 - (id) objectFromJSONString
 {
   SBJsonParser *parser;
-  NSObject *object;
+  NSArray *object;
   NSError *error;
-  NSString *unescaped;
+  NSString *unescaped, *json;
 
   object = nil;
 
@@ -559,13 +559,16 @@ static NSCharacterSet *controlCharSet = nil;
       parser = [SBJsonParser new];
       [parser autorelease];
       error = nil;
-      object = [parser objectWithString: self
+
+      /* Parse it this way so we can parse simple values, like "null" */
+      json = [NSString stringWithFormat: @"[%@]", self];
+      object = [parser objectWithString: json
                                   error: &error];
       if (error)
         {
           [self errorWithFormat: @"json parser: %@,"
                 @" attempting once more after unescaping...", error];
-          unescaped = [self stringByReplacingString: @"\\\\"
+          unescaped = [json stringByReplacingString: @"\\\\"
                                          withString: @"\\"];
           object = [parser objectWithString: unescaped
                                       error: &error];
@@ -579,7 +582,7 @@ static NSCharacterSet *controlCharSet = nil;
         }
     }
 
-  return object;
+  return [object objectAtIndex: 0];
 }
 
 - (NSString *) asSafeSQLString


### PR DESCRIPTION
Contact info is cached as a json string, but current json parser does not support single values (like "null"). 

Any contact outside our domain was not being cached properly ("null" was stored in the cache but we couldn't get it back because objectFromJSONString was failing) and every time an address was found a ldap request was performed against samba.

So in the end this is just to be able to do:

```
NSString *foo = @"\"null\""
[foo objectFromJSONString] == [NSNull nil]
```

For big mailboxes is quite an improvement in performance. (For 19k emails, instead of ~1 hour importing them, it took ~15 minutes).
