### PR TITLE
Attempt to sync an UID in setChangeKey to avoid crashing

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -855,8 +855,11 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
       synced = [self synchroniseCacheForUID: messageUid];
       if (synced)
         messageEntry = [[[versionsMessage properties] objectForKey: @"Messages"] objectForKey: messageUid];
-      else
-        abort ();
+      if (!messageEntry)
+        {
+          [self errorWithFormat: @"still nothing. We crash!"];
+          abort ();
+        }
     }
   [self _setChangeKey: changeKey forMessageEntry: messageEntry];
   


### PR DESCRIPTION
This may happen if between sync cache and setChangeKey a modSeq
is making synchroniseCache not retrieve the newly stored message.

This should fix the following crash:

https://tracker.zentyal.org/issues/2673
