### PR TITLE
Create child folder objects using parent context for real

### DIFF
--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -29,6 +29,7 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSURL.h>
 #import <NGExtensions/NSObject+Logs.h>
+#import <NGObjWeb/WOContext+SoObjects.h>
 #import <SOGo/SOGoContentObject.h>
 #import <SOGo/SOGoUser.h>
 #import <SOGo/SOGoFolder.h>
@@ -235,6 +236,11 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   if ([[self folderKeys] containsObject: folderKey])
     {
       woContext = [[self userContext] woContext];
+      /* We activate the user for the context using the root folder
+         context as there are times where the active user is not
+         matching with the one stored in the application context
+         and SOGo object is storing cached data with the wrong user */
+      [[self userContext] activateWithUser: [woContext activeUser]];
       sogoFolder = [sogoObject lookupName: folderKey inContext: woContext
                                   acquire: NO];
       if (sogoFolder && ![sogoFolder isKindOfClass: NSExceptionK])


### PR DESCRIPTION
We activate the user for the context using the root folder
context as there are times where the active user is not
matching with the one stored in the application context
and SOGo object is storing cached data with the wrong user
leading to create folders in wrong mailboxes, etc.

As this application is single-threaded, no problems are expected.
Indeed, the same code is available at getting the root folder (ie INBOX).
