### PR TITLE
Ignore unhandled properties instead of abort

### DIFF
--- a/OpenChange/MAPIStoreObject.m
+++ b/OpenChange/MAPIStoreObject.m
@@ -256,6 +256,9 @@ static Class NSExceptionK, MAPIStoreFolderK;
     {
       cValue = aRow->lpProps + counter;
       value = NSObjectFromSPropValue (cValue);
+      if (value == nil)
+        continue;
+
       switch (cValue->ulPropTag & 0xffff)
         {
         case PT_STRING8:

--- a/OpenChange/MAPIStoreTypes.m
+++ b/OpenChange/MAPIStoreTypes.m
@@ -154,8 +154,7 @@ NSObjectFromMAPISPropValue (const struct mapi_SPropValue *value)
 // #define	PT_I8			0x14
 // #define	PT_SRESTRICT		0xFD
 // #define	PT_ACTIONS		0xFE
-      result = [NSNull null];
-      abort();
+      result = nil;
       NSLog (@"%s: object type not handled: %d (0x%.4x)",
              __PRETTY_FUNCTION__, valueType, valueType);
     }
@@ -250,8 +249,7 @@ NSObjectFromSPropValue (const struct SPropValue *value)
 // #define	PT_I8			0x14
 // #define	PT_SRESTRICT		0xFD
 // #define	PT_ACTIONS		0xFE
-      result = [NSNull null];
-      abort();
+      result = nil;
       NSLog (@"%s: object type not handled: %d (0x%.4x)",
              __PRETTY_FUNCTION__, valueType, valueType);
     }


### PR DESCRIPTION
Use case to replicate this: send an email in rtf format with an image (the image is a PT_OBJECT property). With this patch the image won't be created and the email won't have it, but at least `abort()` won't be called.
