### PR TITLE
Use PT_SYSTIME as absolute timestamp

### DIFF
--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -29,7 +29,6 @@
 #import <Foundation/NSData.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSString.h>
-#import <Foundation/NSTimeZone.h>
 #import <Foundation/NSValue.h>
 #import <NGExtensions/NGHashMap.h>
 #import <NGExtensions/NSObject+Logs.h>
@@ -673,8 +672,6 @@ FillMessageHeadersFromProperties (NGMutableHashMap *headers,
   date = [mailProperties objectForKey: MAPIPropertyKey (PR_CLIENT_SUBMIT_TIME)];
   if (date)
     {
-      date = [date addYear: 0 month: 0 day: 0
-                      hour: 0 minute: 0 second: [[date timeZone] secondsFromGMT]];
       [headers addObject: [date rfc822DateString] forKey: @"date"];
     }
   [headers addObject: @"1.0" forKey: @"MIME-Version"];

--- a/OpenChange/MAPIStoreObject.m
+++ b/OpenChange/MAPIStoreObject.m
@@ -23,7 +23,6 @@
 #import <Foundation/NSArray.h>
 #import <Foundation/NSCalendarDate.h>
 #import <Foundation/NSDictionary.h>
-#import <Foundation/NSTimeZone.h>
 #import <NGExtensions/NSObject+Logs.h>
 #import <SOGo/SOGoObject.h>
 #import <SOGo/SOGoUser.h>
@@ -245,12 +244,7 @@ static Class NSExceptionK, MAPIStoreFolderK;
   struct SPropValue *cValue;
   NSUInteger counter;
   NSMutableDictionary *newProperties;
-  NSTimeZone *tz;
-  NSInteger tzOffset;
   id value;
-
-  tz = nil;
-  tzOffset = 0;
 
   newProperties = [NSMutableDictionary dictionaryWithCapacity: aRow->cValues];
   for (counter = 0; counter < aRow->cValues; counter++)
@@ -267,16 +261,6 @@ static Class NSExceptionK, MAPIStoreFolderK;
           [self warnWithFormat:
                   @"attempting to set string property as PR_STRING8: %.8x",
                 cValue->ulPropTag];
-          break;
-        case PT_SYSTIME:
-          if (!tz)
-            {
-              tz = [[self userContext] timeZone];
-              tzOffset = -[tz secondsFromGMT];
-            }
-          value = [value addYear: 0 month: 0 day: 0
-                            hour: 0 minute: 0 second: tzOffset];
-          [value setTimeZone: tz];
           break;
         }
       [newProperties setObject: value

--- a/OpenChange/MAPIStoreTypes.m
+++ b/OpenChange/MAPIStoreTypes.m
@@ -119,6 +119,7 @@ NSObjectFromMAPISPropValue (const struct mapi_SPropValue *value)
       break;
     case PT_SYSTIME:
       result = [NSCalendarDate dateFromFileTime: &(value->value.ft)];
+      [result setTimeZone: utcTZ];
       break;
     case PT_BINARY:
     case PT_SVREID:

--- a/OpenChange/iCalEvent+MAPIStore.m
+++ b/OpenChange/iCalEvent+MAPIStore.m
@@ -207,16 +207,7 @@
   value
     = [properties objectForKey: MAPIPropertyKey (PidLidExceptionReplaceTime)];
   if (value)
-    {
-      if (!isAllDay)
-        {
-          tzOffset = [userTimeZone secondsFromGMTForDate: value];
-          value = [value dateByAddingYears: 0 months: 0 days: 0
-                                     hours: 0 minutes: 0
-                                   seconds: tzOffset];
-        }
-      [self setRecurrenceId: value];
-    }
+    [self setRecurrenceId: value];
  
   // start
   value = [properties objectForKey: MAPIPropertyKey (PidLidAppointmentStartWhole)];
@@ -241,13 +232,7 @@
           [start setTimeZone: nil];
         }
       else
-        {
-          tzOffset = [userTimeZone secondsFromGMTForDate: value];
-          value = [value dateByAddingYears: 0 months: 0 days: 0
-                                     hours: 0 minutes: 0
-                                   seconds: tzOffset];
           [start setDateTime: value];
-        }
     }
 
   /* end */
@@ -273,13 +258,7 @@
           [end setTimeZone: nil];
         }
       else
-        {
-          tzOffset = [[value timeZone] secondsFromGMTForDate: value];
-          value = [value dateByAddingYears: 0 months: 0 days: 0
-                                     hours: 0 minutes: 0
-                                   seconds: tzOffset];
           [end setDateTime: value];
-        }
     }
 
   /* priority */


### PR DESCRIPTION
Thus the associated timezone is UTC.

Adjusting properties which shift the date are now reverted and some fixed according to specs. See the following table for details:

* `PidTagSubmitTime` (Sent field in the mail) is now set properly
* Use UTC date in `date` field in MIME message (RFC 822)
* Fix start, end and complete dates for tasks
* Fix start, end and replace time for calendar events (This should fix the exception shifting)