### PR TITLE
oc-mail: Move mail folders with reserved chars

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1217,7 +1217,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
   NGImap4Connection *connection;
   NGImap4Client *client;
   NSString *newURL, *parentDBFolderPath, *childKey, *folderIMAPName,
-    *urlNamePart, *newFolderIMAPName;
+    *urlNamePart, *newFolderIMAPName, *newFolderDBName;
   NSException *error;
   MAPIStoreMapping *mapping;
   NSDictionary *result;
@@ -1230,7 +1230,8 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
       targetSOGoFolder = [targetFolder sogoObject];
       if (isMove)
         {
-          urlNamePart = [newFolderName stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+          /* Mimetise [SOGoMailFolderK imap4URLString] */
+          urlNamePart = [[newFolderName stringByEncodingImap4FolderName] stringByEscapingURL];
           newFolderURL = [NSURL URLWithString: urlNamePart
                                 relativeToURL: [targetSOGoFolder imap4URL]];
           error = [[sogoObject imap4Connection]
@@ -1242,8 +1243,9 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
             {
               rc = MAPISTORE_SUCCESS;
               mapping = [self mapping];
+              newFolderDBName = [[newFolderName stringByEncodingImap4FolderName] asCSSIdentifier];
               newURL = [NSString stringWithFormat: @"%@folder%@/",
-                                 [targetFolder url], urlNamePart];
+                                 [targetFolder url], newFolderDBName];
               [mapping updateID: [self objectId] withURL: newURL];
               parentDBFolderPath = [[targetFolder dbFolder] path];
               if (!parentDBFolderPath)
@@ -1251,7 +1253,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
               [dbFolder changePathTo: [NSString stringWithFormat:
                                                   @"%@/folder%@",
                                                 parentDBFolderPath,
-                                                newFolderName]];
+                                                newFolderDBName]];
             }
         }
       else


### PR DESCRIPTION
The URL was incorrectly set when any of ;/?:@&=+$,# was used
in the folder name.