### PR TITLE
oc: Move back and forth folders now are in sync

### DIFF
--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -916,16 +916,23 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
             }
 
           if (isMove)
-            {
-              fmid = [mapping idFromURL: [self url]];
-              [mapping unregisterURLWithID: fmid];
               [self deleteFolder];
-              [mapping registerURL: [newFolder url]
-                            withID: fmid];
-            }
+
           [targetFolder cleanupCaches];
         }
       [self cleanupCaches];
+
+      /* We perform the mapping operations at the
+         end as objectId is required to be available
+         until the caches are cleaned up */
+      if (isMove && rc == MAPISTORE_SUCCESS)
+        {
+          fmid = [mapping idFromURL: [self url]];
+          [mapping unregisterURLWithID: fmid];
+          [mapping registerURL: [newFolder url]
+                        withID: fmid];
+        }
+
     }
   else
     rc = MAPISTORE_ERR_DENIED;


### PR DESCRIPTION
Two different indexing entries were created on move operation making
impossible to restore old folder position in the original parent folder.
This was due to cleanupCaches message calls to objectId which requires
to have the indexing entry available.

Use case:

  * Restore a folder from "Deleted items" folders