### PR TITLE
oc-appointments: ignore alarms from the past

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -1836,15 +1836,26 @@ ReservedBlockEE2Size: 00 00 00 00
   NSUInteger count, max;
   iCalAlarm *currentAlarm;
   NSString *action;
+  NSCalendarDate *now, *alarmDate;
 
   alarms = [event alarms];
   max = [alarms count];
+  now = [NSCalendarDate calendarDate];
   for (count = 0; !alarm && count < max; count++)
     {
       currentAlarm = [alarms objectAtIndex: count];
-      action = [[currentAlarm action] lowercaseString];
-      if (!action || [action isEqualToString: @"display"])
-        ASSIGN (alarm, currentAlarm);
+
+      // Only handle 'display' alarms
+      action = [currentAlarm action];
+      if ([action caseInsensitiveCompare: @"display"] != NSOrderedSame)
+        continue;
+
+      // Only set alarms from the future!
+      alarmDate = [[currentAlarm trigger] nextAlarmDate];
+      if ([alarmDate compare: now] != NSOrderedDescending)
+        continue;
+
+      ASSIGN (alarm, currentAlarm);
     }
 
   alarmSet = YES;


### PR DESCRIPTION
Outlook behavior is to show up alarms even if they are from the past, once they are showed up they are removed. We don't want those to appear, so just filter the alarms from the past.