### PR TITLE
oc: Set right container in dbFolder when moving a folder

### DIFF
--- a/OpenChange/MAPIStoreDBFolder.m
+++ b/OpenChange/MAPIStoreDBFolder.m
@@ -152,7 +152,8 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
       targetPath = [[targetFolder sogoObject] path];
       newPath = [NSString stringWithFormat: @"%@/%@",
                           targetPath, pathComponent];
-      [dbFolder changePathTo: newPath];
+      [dbFolder changePathTo: newPath
+            intoNewContainer: [targetFolder dbFolder]];
       
       mapping = [self mapping];
       newURL = [NSString stringWithFormat: @"%@%@/",

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1286,7 +1286,8 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
               [dbFolder changePathTo: [NSString stringWithFormat:
                                                   @"%@/folder%@",
                                                 parentDBFolderPath,
-                                                newFolderDBName]];
+                                                newFolderDBName]
+                      intoNewContainer: [targetFolder dbFolder]];
             }
         }
       else

--- a/SoObjects/SOGo/SOGoCacheGCSFolder.h
+++ b/SoObjects/SOGo/SOGoCacheGCSFolder.h
@@ -49,6 +49,8 @@
              andSortOrderings: (NSArray *) sortOrderings;
 
 - (void) changePathTo: (NSString *) newPath;
+- (void) changePathTo: (NSString *) newPath
+     intoNewContainer: (id) newContainer;
 
 @end
 

--- a/SoObjects/SOGo/SOGoCacheGCSFolder.m
+++ b/SoObjects/SOGo/SOGoCacheGCSFolder.m
@@ -308,6 +308,14 @@ Class SOGoCacheGCSObjectK = Nil;
   [super changePathTo: newPath];
 }
 
+- (void) changePathTo: (NSString *) newPath intoNewContainer: (id) newContainer
+{
+  [self changePathTo: newPath];
+  container = newContainer;
+  if ([self doesRetainContainer])
+    [container retain];
+}
+
 // - (NSArray *) toOneRelationshipKeysMatchingQualifier: (EOQualifier *) qualifier
 //                                     andSortOrderings: (NSArray *) sortOrderings
 // {

--- a/SoObjects/SOGo/SOGoObject.h
+++ b/SoObjects/SOGo/SOGoObject.h
@@ -82,6 +82,8 @@
 
 - (BOOL) isInPublicZone;
 
+- (BOOL) doesRetainContainer;
+
 /* accessors */
 
 - (void) setContext: (WOContext *) newContext;


### PR DESCRIPTION
The path attribute from `SOGoCacheGCSFolder` is properly updated
in the database but not when returning from `path` message as
the container is the old one.