### PR TITLE
Move subfolder (Mail, Journal, Notes) to root

### DIFF
--- a/OpenChange/MAPIStoreDBFolder.m
+++ b/OpenChange/MAPIStoreDBFolder.m
@@ -140,7 +140,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
 
   pathComponent = nil;
 
-  if (isMove && [targetFolder isKindOfClass: MAPIStoreDBFolderK])
+  if (isMove && ([targetFolder isKindOfClass: MAPIStoreDBFolderK] || !targetFolder))
     {
       path = [sogoObject path];
       slashRange = [path rangeOfString: @"/" options: NSBackwardsSearch];
@@ -149,15 +149,28 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
                     format: @"db folder path must start with a '/'"];
       else
         pathComponent = [path substringFromIndex: slashRange.location + 1];
-      targetPath = [[targetFolder sogoObject] path];
-      newPath = [NSString stringWithFormat: @"%@/%@",
-                          targetPath, pathComponent];
-      [dbFolder changePathTo: newPath
-            intoNewContainer: [targetFolder dbFolder]];
+
+      if (targetFolder)
+        {
+          targetPath = [[targetFolder sogoObject] path];
+          newPath = [NSString stringWithFormat: @"%@/%@",
+                              targetPath, pathComponent];
+          [dbFolder changePathTo: newPath
+                intoNewContainer: [targetFolder dbFolder]];
+        }
+      else
+        [dbFolder changePathTo: [NSString stringWithFormat: @"/fallback/%@", pathComponent]
+              intoNewContainer: nil];
       
       mapping = [self mapping];
-      newURL = [NSString stringWithFormat: @"%@%@/",
-                         [targetFolder url], pathComponent];
+
+      if (targetFolder)
+        newURL = [NSString stringWithFormat: @"%@%@/",
+                           [targetFolder url], pathComponent];
+      else
+        newURL = [NSString stringWithFormat: @"sogo://%@@fallback/%@/",
+                           [[self userContext] username], pathComponent];
+
       [mapping updateID: [self objectId]
                 withURL: newURL];
 


### PR DESCRIPTION
Once openchange/openchange#200 is merged, a NULL pointer can be passed as target folder in move folder operation, then we can become the moved folder into a root folder.

By now, it is only implement for MAPIStoreMailFolder and MAPIStoreDBFolder (Notes, Journal) as MAPIStoreGCSFolder does not implement to have subfolders and it is assumed throughout SOGo code the subfolders have the same role that its parent has.
