### PR TITLE
oc-calendar: Implement categories to share the colour

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -45,6 +45,7 @@
 #import "MAPIStoreRecurrenceUtils.h"
 #import "MAPIStoreSamDBUtils.h"
 #import "MAPIStoreTypes.h"
+#import "NSArray+MAPIStore.h"
 #import "NSData+MAPIStore.h"
 #import "NSDate+MAPIStore.h"
 #import "NSObject+MAPIStore.h"
@@ -1241,6 +1242,22 @@ static NSCharacterSet *hexCharacterSet = nil;
   *data = MAPILongValue (memCtx, v);
 
   return MAPISTORE_SUCCESS;
+}
+
+- (int) getPidNameKeywords: (void **) data
+                  inMemCtx: (TALLOC_CTX *) memCtx
+{
+  /* See [MS-OXCICAL] Section 2.1.3.1.1.20.3 */
+  NSArray *categories;
+
+  categories = [event categories];
+  if (categories)
+    {
+      *data = [categories asMVUnicodeInMemCtx: memCtx];
+      return MAPISTORE_SUCCESS;
+    }
+  else
+    return MAPISTORE_ERR_NOT_FOUND;
 }
 
 - (int) getPidTagBody: (void **) data

--- a/OpenChange/iCalEvent+MAPIStore.m
+++ b/OpenChange/iCalEvent+MAPIStore.m
@@ -305,6 +305,12 @@
   if (class)
     [self setAccessClass: class];
 
+  /* Categories */
+  /* See [MS-OXCICAL] Section 2.1.3.1.1.20.3 */
+  value = [properties objectForKey: MAPIPropertyKey (PidNameKeywords)];
+  if (value)
+    [self setCategories: value];
+
   /* show time as free/busy/tentative/out of office. Possible values are:
      0x00000000 - olFree
      0x00000001 - olTentative


### PR DESCRIPTION
See [MS-OXCICAL] Section 2.1.3.1.1.20.3 for details.

It requires https://github.com/openchange/openchange/pull/216 to retrieve
the value from MAPI client