### PR TITLE
MAPIStoreAppointmentWrapper: in _computeGlobalObjectIds create id for ev...

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -38,6 +38,7 @@
 #import <NGCards/iCalPerson.h>
 #import <NGCards/iCalTrigger.h>
 #import <NGCards/NSString+NGCards.h>
+#import <SOGo/SOGoObject.h>
 #import <SOGo/SOGoUser.h>
 #import <SOGo/SOGoUserManager.h>
 
@@ -1725,11 +1726,16 @@ ReservedBlockEE2Size: 00 00 00 00
   NSData *binPrefix;
   TALLOC_CTX *localMemCtx;
 
-  localMemCtx = talloc_zero (NULL, TALLOC_CTX);
+  localMemCtx = talloc_zero(NULL, TALLOC_CTX);
 
   memset (&newGlobalId, 0, sizeof (struct GlobalObjectId));
 
   uid = [event uid];
+  if (uid == NULL) {
+    uid = [SOGoObject globallyUniqueObjectId];
+    [event setUid: uid];
+  }
+
   uidLength = [uid length];
   if (uidLength >= 82 && (uidLength % 2) == 0 && [uid hasPrefix: prefix]
       && [[uid stringByTrimmingCharactersInSet: hexCharacterSet] length] == 0)


### PR DESCRIPTION
...ent if it don't have none

This is to prevent a strlen crash when the event id is NULL.