### PR TITLE
Give support to calendar sharing invitation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ master
 ------
 
 Enhancements
+ - Give support to calendar sharing invitations
  - Missing contact fields are now saved and available when sharing it
     (Office, Profession, Manager's name, Assistant's name, Spouse/Partner, Anniversary)
  - Appointment color and importance work now between Outlooks

--- a/OpenChange/GNUmakefile
+++ b/OpenChange/GNUmakefile
@@ -110,6 +110,8 @@ $(SOGOBACKEND)_OBJC_FILES += \
 	\
 	MAPIStoreFallbackContext.m \
 	\
+	MAPIStoreSharingMessage.m \
+	\
 	NSArray+MAPIStore.m \
 	NSData+MAPIStore.m \
 	NSDate+MAPIStore.m \

--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -186,6 +186,14 @@
             [(SOGoAppointmentFolder *) sogoObject aclSQLListingFilter]];
 }
 
+- (int) getPidTagContainerClass: (void **) data
+                       inMemCtx: (TALLOC_CTX *) memCtx
+{
+  *data = [@"IPF.Appointment" asUnicodeInMemCtx: memCtx];
+
+  return MAPISTORE_SUCCESS;
+}
+
 - (int) getPidTagDefaultPostMessageClass: (void **) data
                                 inMemCtx: (TALLOC_CTX *) memCtx
 {

--- a/OpenChange/MAPIStoreMailAttachment.m
+++ b/OpenChange/MAPIStoreMailAttachment.m
@@ -163,8 +163,15 @@
 - (int) getPidTagDisplayName: (void **) data
                     inMemCtx: (TALLOC_CTX *) memCtx
 {
-  *data = [[bodyInfo objectForKey: @"description"]
-            asUnicodeInMemCtx: memCtx];
+  NSString *fileName;
+
+  fileName = [self _fileName];
+  if ([fileName isEqualToString: @"sharing_metadata.xml"])
+    /* Required to disallow user from seeing the attachment by default */
+    *data = [@"sharing_metadata.xml" asUnicodeInMemCtx: memCtx];
+  else
+    *data = [[bodyInfo objectForKey: @"description"]
+              asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
@@ -181,11 +188,17 @@
 - (int) getPidTagAttachMimeTag: (void **) data
                       inMemCtx: (TALLOC_CTX *) memCtx
 {
-  NSString *mimeTag;
+  NSString *mimeTag, *fileName;
 
-  mimeTag = [NSString stringWithFormat: @"%@/%@",
-                [bodyInfo objectForKey: @"type"],
-                [bodyInfo objectForKey: @"subtype"]];
+  fileName = [self _fileName];
+  if ([fileName isEqualToString: @"sharing_metadata.xml"])
+    /* Required by [MS-OXWSMSHR] Section 3.1.1 */
+    mimeTag = [NSString stringWithFormat: @"application/x-sharing-metadata-xml"];
+  else
+    mimeTag = [NSString stringWithFormat: @"%@/%@",
+                  [bodyInfo objectForKey: @"type"],
+                  [bodyInfo objectForKey: @"subtype"]];
+
   *data = [[mimeTag lowercaseString] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;

--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -35,6 +35,7 @@
 {
   BOOL headerSetup;
   BOOL mailIsEvent;
+  BOOL mailIsSharingObject;
   NSString *mimeKey;
   NSString *headerCharset;
   NSString *headerEncoding;

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -154,6 +154,30 @@ static Class NSExceptionK;
   return [sogoObject date];
 }
 
+- (enum mapistore_error) getAvailableProperties: (struct SPropTagArray **) propertiesP
+                                       inMemCtx: (TALLOC_CTX *) memCtx
+{
+  BOOL listedProperties[65536];
+  NSUInteger count;
+  uint16_t propId;
+
+  if (mailIsSharingObject)
+    {
+      memset (listedProperties, NO, 65536 * sizeof (BOOL));
+      [super getAvailableProperties: propertiesP inMemCtx: memCtx];
+      for (count = 0; count < (*propertiesP)->cValues; count++)
+        {
+          propId = ((*propertiesP)->aulPropTag[count] >> 16) & 0xffff;
+          listedProperties[propId] = YES;
+        }
+      [MAPIStoreSharingMessage fillAvailableProperties: *propertiesP
+                                        withExclusions: listedProperties];
+      return MAPISTORE_SUCCESS;
+    }
+  else
+    return [super getAvailableProperties: propertiesP inMemCtx: memCtx];
+}
+
 static NSComparisonResult
 _compareBodyKeysByPriority (id entry1, id entry2, void *data)
 {

--- a/OpenChange/MAPIStoreSharingMessage.h
+++ b/OpenChange/MAPIStoreSharingMessage.h
@@ -1,0 +1,94 @@
+/* MAPIStoreSharingMessage.h - this file is part of SOGo-OpenChange
+ *
+ * Copyright (C) 2015 Enrique J. Hernández
+ *
+ * Author: Enrique J. Hernández <ejhernandez@zentyal.com>
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef MAPISTORESHARINGMESSAGE_H
+#define MAPISTORESHARINGMESSAGE_H
+
+#import "MAPIStoreObjectProxy.h"
+
+
+@interface MAPIStoreSharingMessage : MAPIStoreObjectProxy
+{
+  struct mapistore_connection_info *connInfo;
+  NSMutableDictionary *properties;
+}
+
+- (id) initWithMailHeaders: (NSDictionary *) mailHeaders
+         andConnectionInfo: (struct mapistore_connection_info *) newConnInfo;
+
+/* getters */
+- (int) getPidLidSharingCapabilities: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingCapabilities: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingConfigurationUrl: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingConfigUrl: (void **) data
+                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingFlavor: (void **) data
+                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingFlavor: (void **) data
+                        inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingInitiatorEntryId: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingInitiatorName: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingInitiatorSmtp: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingLocalType: (void **) data
+                         inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingLocalType: (void **) data
+                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingProviderGuid: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingProviderGuid: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingProviderName: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingProviderName: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingProviderUrl: (void **) data
+                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingProviderUrl: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingRemoteName: (void **) data
+                          inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingRemoteName: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingRemoteStoreUid: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameXSharingRemoteStoreUid: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingRemoteType: (void **) data
+                          inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidTypeXSharingRemoteType: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingResponseTime: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidSharingResponseType: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidNameContentClass: (void **) data
+                      inMemCtx: (TALLOC_CTX *) memCtx;
+
+@end
+
+#endif /* MAPISTORECALENDARWRAPPER_H */

--- a/OpenChange/MAPIStoreSharingMessage.m
+++ b/OpenChange/MAPIStoreSharingMessage.m
@@ -1,0 +1,372 @@
+/* MAPIStoreSharingMessage.m - this file is part of SOGo-OpenChange
+ *
+ * Copyright (C) 2015 Enrique J. Hernández
+ *
+ * Author: Enrique J. Hernández <ejhernandez@zentyal.com>
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <talloc.h>
+
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+
+#import <NGExtensions/NGBase64Coding.h>
+
+#import "MAPIStoreTypes.h"
+#import "NSData+MAPIStore.h"
+#import "NSDate+MAPIStore.h"
+#import "NSString+MAPIStore.h"
+#import "NSValue+MAPIStore.h"
+
+#import "MAPIStoreSharingMessage.h"
+
+#include <mapistore/mapistore_errors.h>
+
+@implementation MAPIStoreSharingMessage
+
+- (id) init
+{
+  if ((self = [super init]))
+    {
+      connInfo = NULL;
+      properties = nil;
+    }
+
+  return self;
+}
+
+- (id) initWithMailHeaders: (NSDictionary *) mailHeaders
+         andConnectionInfo: (struct mapistore_connection_info *) newConnInfo
+{
+  NSEnumerator *enumerator;
+  NSString *key;
+
+  if ((self = [self init]))
+    {
+      connInfo = newConnInfo;
+      enumerator = [mailHeaders keyEnumerator];
+      properties = [NSMutableDictionary new];
+      while ((key = [enumerator nextObject]))
+        {
+          if ([key hasPrefix: @"x-ms-sharing-"])
+            [properties setObject: [mailHeaders objectForKey: key]
+                           forKey: key];
+        }
+    }
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [properties release];
+  [super dealloc];
+}
+
+- (enum mapistore_error) _getStringProperty: (NSString *) propertyName
+                                     inData: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
+{
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: propertyName];
+  if (value)
+    {
+      *data = [value asUnicodeInMemCtx: memCtx];
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+
+}
+
+- (int) getPidLidSharingCapabilities: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-capabilities"];
+  if (value)
+    {
+      *data = MAPILongValue (memCtx, [value intValue]);
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidNameXSharingCapabilities: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
+{
+
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-capabilities"];
+  if (value)
+    {
+      *data = [[value stringValue] asUnicodeInMemCtx: memCtx];
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidLidSharingConfigurationUrl: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
+{
+
+  *data = [@"" asUnicodeInMemCtx: memCtx];
+  return MAPISTORE_SUCCESS;
+}
+
+- (int) getPidNameXSharingConfigUrl: (void **) data
+                           inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingConfigurationUrl: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingFlavor: (void **) data
+                      inMemCtx: (TALLOC_CTX *) memCtx
+{
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-flavor"];
+  if (value)
+    {
+      *data = MAPILongValue (memCtx, [value intValue]);
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidNameXSharingFlavor: (void **) data
+                        inMemCtx: (TALLOC_CTX *) memCtx
+{
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-flavor"];
+  if (value)
+    {
+      *data = [[value stringValue] asUnicodeInMemCtx: memCtx];
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidLidSharingInitiatorEntryId: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
+{
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+  NSData *entryId;
+
+  value = [properties objectForKey: @"x-ms-sharing-initiatorentryid"];
+  if (value)
+    {
+      entryId = [value dataByDecodingBase64];
+      if (entryId)
+        {
+          *data = [entryId asBinaryInMemCtx: memCtx];
+          rc = MAPISTORE_SUCCESS;
+        }
+    }
+
+  return rc;
+}
+
+- (int) getPidLidSharingInitiatorName: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-initiatorname"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingInitiatorSmtp: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-initiatorsmtp"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingLocalType: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-localtype"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidNameXSharingLocalType: (void **) data
+                           inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingLocalType: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingProviderGuid: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  const unsigned char providerGuidBytes[] = {0xAE, 0xF0, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                             0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46};
+  NSData *providerGuid = [NSData dataWithBytes: providerGuidBytes length: 16];
+  *data = [providerGuid asBinaryInMemCtx: memCtx];
+  return MAPISTORE_SUCCESS;
+}
+
+- (int) getPidNameXSharingProviderGuid: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
+{
+  *data = [@"AEF0060000000000C000000000000046" asUnicodeInMemCtx: memCtx];
+  return MAPISTORE_SUCCESS;
+}
+
+- (int) getPidLidSharingProviderName: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+
+  return [self _getStringProperty: @"x-ms-sharing-providername"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidNameXSharingProviderName: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingProviderName: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingProviderUrl: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-providerurl"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidNameXSharingProviderUrl: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingProviderUrl: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingRemoteName: (void **) data
+                          inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-remotename"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidNameXSharingRemoteName: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingRemoteName: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingRemoteStoreUid: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-remotestoreuid"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidNameXSharingRemoteStoreUid: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingRemoteStoreUid: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingRemoteType: (void **) data
+                          inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-remotetype"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidTypeXSharingRemoteType: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingRemoteType: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingRemoteUid: (void **) data
+                          inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self _getStringProperty: @"x-ms-sharing-remoteuid"
+                           inData: data
+                         inMemCtx: memCtx];
+}
+
+- (int) getPidUidXSharingRemoteUid: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  return [self getPidLidSharingRemoteUid: data inMemCtx: memCtx];
+}
+
+- (int) getPidLidSharingResponseTime: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-responsetime"];
+  if (value)
+    {
+      *data = [value asFileTimeInMemCtx: memCtx];
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidLidSharingResponseType: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  id value;
+
+  value = [properties objectForKey: @"x-ms-sharing-responsetype"];
+  if (value)
+    {
+      *data = MAPILongValue (memCtx, [value intValue]);
+      rc = MAPISTORE_SUCCESS;
+    }
+
+  return rc;
+}
+
+- (int) getPidNameContentClass: (void **) data
+                      inMemCtx: (TALLOC_CTX *) memCtx
+{
+    *data = talloc_strdup (memCtx, "Sharing");
+    return MAPISTORE_SUCCESS;
+}
+
+@end


### PR DESCRIPTION
By implementing the Sharing Message object (`MAPIStoreSharingMessage`) as a proxy of `MAPIStoreMailMessage` storing the sharing properties from [MS-OXSHARE] as eXtensible MIME headers of the mail.

In addition to this, it is required to have custom properties values when the attached file is called `sharing_metadata.xml` as described in [MS-OXWSMSHR] Section 3.1.1.

It requires https://github.com/openchange/openchange/pull/223 to work.