### PR TITLE
oc-mail: Set sender on email messages without an orig recipient

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ Enhancements
  - Appointment color and importance work now between Outlooks
 
 Bug fixes
+ - Fix sender on importing email messages like event invitations
  - Fix Outlook crashes when modifying the view of a folder
  - Fix server side crash when reading some recurrence appointments
 


### PR DESCRIPTION
But it has recipients. This is for sure happening with event invitations messages and when the recipient list does not include `orig` key.