### PR TITLE
oc-rtf: safe parse ignoring content

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Enhancements
  - Appointment color and importance work now between Outlooks
 
 Bug fixes
+ - Fix server side crash parsing rtf emails with images (with word97 format)
  - Fix sender on importing email messages like event invitations
  - Fix Outlook crashes when modifying the view of a folder
  - Fix server side crash when reading some recurrence appointments

--- a/OpenChange/RTFHandler.m
+++ b/OpenChange/RTFHandler.m
@@ -660,22 +660,17 @@ const unsigned short ansicpg874[256] = {
    } while (count != 0); 
 }
 
-//
-//
-//
-- (void) parsePicture
+- (void) parseIgnoringEverything
 {
+  unsigned int count = 1;
   // Ignore everything. But we cannot parse it blindly because it could have
   // binary data with '}' and '{' bytes, so disasters can happen and they will
-  unsigned int count = 0;
-  const char *cw;
-
   do
     {
       if (*_bytes == '\\')
         {
           unsigned int binary_size, len = 0, cw_len;
-          cw = [self parseControlWord: &len];
+          const char *cw = [self parseControlWord: &len];
           cw_len = strlen("bin");
           if (strncmp(cw, "bin", cw_len) == 0 && len > cw_len)
             {
@@ -688,23 +683,21 @@ const unsigned short ansicpg874[256] = {
               binary_size = [s intValue];
               ADVANCE_N(binary_size);
             }
-          else if (len > 0)
-            {
-              ADVANCE_N(len);
-            }
-          else
-            {
-              ADVANCE;
-            }
         }
-      else
-        {
-          if (*_bytes == '{') count++;
-          if (*_bytes == '}') count--;
-          ADVANCE;
-        }
+
+      if (*_bytes == '{') count++;
+      if (*_bytes == '}') count--;
+      ADVANCE;
     }
   while (count > 0);
+}
+
+//
+//
+//
+- (void) parsePicture
+{
+  [self parseIgnoringEverything];
 }
 
 //
@@ -771,19 +764,7 @@ const unsigned short ansicpg874[256] = {
             }
           else if (*(_bytes+1) == '*')
             {
-	      int cc = 1;
-	      
-	      do
-                {
-                  if (*_bytes == '{')
-                    cc++;
-                  if (*_bytes == '}')
-                    cc--;
-                  
-                  ADVANCE;
-                }
-              while (cc != 0);
-
+              [self parseIgnoringEverything];
               continue;
             }
 


### PR DESCRIPTION
Be able to parse safely `\*\xxxxx` control words (they are just ignored) with `\bin` elements inside it.

This is a rewrite of the `parsePicture` function (which was wrong) and make it generic to parse anything.