### PR TITLE
oc-mail: Fix crash on syncing deleted items

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Enhancements
  - Appointment color and importance work now between Outlooks
 
 Bug fixes
+ - Fix crash on syncing at Outlook profile start
  - Fix sender on importing email messages like event invitations
  - Fix Outlook crashes when modifying the view of a folder
  - Fix server side crash when reading some recurrence appointments

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -657,6 +657,17 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
               [self logWithFormat:@"Message entry not found for UID %@", uid];
             }
         }
+      /* If the SyncLastDeleteChangeNumber does not exist and we have deleted items
+         to return, we have to set, at least, a change number. This avoids a crash when
+         getting the deleted FMIDs. */
+      if (max > 0 && !changeNumber && ![currentProperties objectForKey: @"SyncLastDeleteChangeNumber"])
+        {
+          newChangeNum = [[self context] getNewChangeNumber];
+          changeNumber = [NSString stringWithUnsignedLongLong: newChangeNum];
+          [self logWithFormat: @"Created change number as %d were deleted and no SyncLastDeleteChangeNumber was available",
+                max];
+        }
+
       if (changeNumber)
         {
           [currentProperties setObject: changeNumber


### PR DESCRIPTION
It crashes because we are returning deleted fmids without a
valid change number in sogo_folder_get_deleted_fmids.

This was due in the synchroniseCache process during the
process of vanished items, the deleted message was not
available in versions plist and there were no
SyncLastDeleteChangeNumber so we need to create the entry
with a change number to avoid this problem.

We can reproduce it by creating a profile in Outlook
, close it, create and delete messages using an IMAP client,
and finally reopen the Outlook.