### PR TITLE
oc-mail: Register source message as soft deleted on movement

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Enhancements
  - Appointment color and importance work now between Outlooks
 
 Bug fixes
+ - Sent mails are not longer in Drafts folder using Outlook
  - Fix sender on importing email messages like event invitations
  - Fix Outlook crashes when modifying the view of a folder
  - Fix server side crash when reading some recurrence appointments

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1163,13 +1163,20 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
   if (![[result objectForKey: @"result"] boolValue])
     return MAPISTORE_ERROR;
 
-  /* "Move" treatment: Store \Deleted and unregister urls */
+  /* "Move" treatment: Store \Deleted and unregister urls as soft-deleted */
   if (!wantCopy)
     {
       [client storeFlags: [NSArray arrayWithObject: @"Deleted"] forUIDs: uids
              addOrRemove: YES];
       for (count = 0; count < midCount; count++)
-        [mapping unregisterURLWithID: srcMids[count]];
+        {
+          /* Using soft-deleted to make deleted fmids to return the
+             srcMids.
+             See [MAPIStoreFolder getDeletedFMIDs:andCN:fromChangeNumber:inTableType:inMemCtx]
+             for details */
+          [mapping unregisterURLWithID: srcMids[count]
+                              andFlags: MAPISTORE_SOFT_DELETE];
+        }
     }
 
   /* Registration of target messages */


### PR DESCRIPTION
This makes sent mails are not longer automatically copied
to Drafts folder.

Reasoning:

When Outlook sends a mail, OpenChange submits the message and
copy the message to Drafts folder. Afterwards, the client asks
to move this message using SyncImportMessageMove ROP from
Drafts to Sent. During this movement, the message is unregistered
from the indexing database. If the client has updated Drafts
folder before that movement, then the client will keep this
message as the MID is not returned in oxcfxics download sync
as deleted. Setting the message as soft deleted, make it work.