### PR TITLE
Use body.peek to preload message bodies

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ master
 ------
 
 Enhancements
+ - Improve sync speed from Outlook by non-reprocessing already downloaded unread mails
  - Give support to calendar sharing invitations
  - Missing contact fields are now saved and available when sharing it
     (Office, Profession, Manager's name, Assistant's name, Spouse/Partner, Anniversary)

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1500,6 +1500,15 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                     {
                       [bodyPartKeys addObject: bodyPartKey];
                       messageUid = [self messageUIDFromMessageKey: messageKey];
+                      /* If the bodyPartKey include peek, remove it as it is not returned
+                         as key in the IMAP server response.
+
+                         IMAP conversation example:
+                         a4 UID FETCH 1 (UID BODY.PEEK[text])
+                         * 1 FETCH (UID 1 BODY[TEXT] {1677}
+                      */
+                      bodyPartKey = [bodyPartKey stringByReplacingOccurrencesOfString: @"body.peek"
+                                                                           withString: @"body"];
                       [keyAssoc setObject: bodyPartKey forKey: messageUid];
                     }
                 }

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1476,10 +1476,8 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
   NSUInteger count, max;
   NSString *messageKey, *messageUid, *bodyPartKey;
   NGImap4Client *client;
-  NSArray *fetch, *flags;
+  NSArray *fetch;
   NSData *bodyContent;
-  BOOL unseen;
-  NSMutableArray *unseenUIDs;
 
   if (tableType == MAPISTORE_MESSAGE_TABLE)
     {
@@ -1509,25 +1507,6 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
       
           client = [[(SOGoMailFolder *) sogoObject imap4Connection] client];
           [client select: [sogoObject absoluteImap4Name]];
-
-          /* Fetch flags to remove seen flag if required,
-             as fetching a message body set the seen flag */
-          response = [client fetchUids: [keyAssoc allKeys]
-                                 parts: [NSArray arrayWithObjects: @"flags", nil]];
-          fetch = [response objectForKey: @"fetch"];
-          max = [fetch count];
-          unseenUIDs = [NSMutableArray arrayWithCapacity: max];
-          for (count = 0; count < max; count++)
-            {
-              response = [fetch objectAtIndex: count];
-              messageUid = [[response objectForKey: @"uid"] stringValue];
-              flags = [response objectForKey: @"flags"];
-              unseen = [flags indexOfObject: @"seen"] == NSNotFound;
-              if (unseen) {
-                [unseenUIDs addObject: messageUid];
-              }
-            }
-
           response = [client fetchUids: [keyAssoc allKeys]
                              parts: [bodyPartKeys allObjects]];
           fetch = [response objectForKey: @"fetch"];
@@ -1548,14 +1527,6 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                       [bodyData setObject: bodyContent forKey: messageKey];
                     }
                 }
-            }
-
-          // Restore unseen state once the body has been fetched
-          if ([unseenUIDs count] > 0)
-            {
-              response = [client storeFlags: [NSArray arrayWithObjects: @"seen", nil]
-                                    forUIDs: unseenUIDs
-                                addOrRemove: NO];
             }
         }
     }

--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -74,7 +74,6 @@
 /* batch-mode helpers */
 - (NSString *) bodyContentPartKey;
 - (void) setBodyContentFromRawData: (NSData *) rawContent;
-- (BOOL) read; /* Unseen from sogoObject */
 
 @end
 

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1660,12 +1660,4 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
     }
 }
 
-- (BOOL) read
-{
-  if (!headerSetup)
-    [self _fetchHeaderData];
-
-  return [sogoObject read];
-}
-
 @end

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1627,11 +1627,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   if (!headerSetup)
     [self _fetchHeaderData];
 
-  if ([mimeKey hasPrefix: @"body.peek"])
-    bodyPartKey = [NSString stringWithFormat: @"body[%@]",
-                          [mimeKey _strippedBodyKey]];
-  else
-    bodyPartKey = mimeKey;
+  bodyPartKey = mimeKey;
 
   return bodyPartKey;
 }


### PR DESCRIPTION
In this way, we do not modify the flags (\Seen) on preloading.
The IMAP server returns the content without .peek section so
it is removed.

This also performs the modification intended by the following
Pull Request (#50) that tried to avoid set \Seen flag when preloading message bodies
on synchronisation. But in this case we are not incrementing the
modseq as we are not modifying any messages flags.

Thanks to @figarocorso  for the hint past October 2014.