### PR TITLE
Fix decoding in recipients

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ Bug fixes
  - Fix sender on importing email messages like event invitations
  - Fix Outlook crashes when modifying the view of a folder
  - Fix server side crash when reading some recurrence appointments
+ - Fix MIME encoding appearing in recipients with underscore
 
 2.2.15 (2015-01-30)
 -------------------

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -442,48 +442,6 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
   *dataPtr = msgData;
 }
 
-static inline NSString *
-MakeRecipientString (NSDictionary *recipient)
-{
-  NSString *fullName, *email, *fullEmail;
-
-  fullName = [recipient objectForKey: @"fullName"];
-  email = [recipient objectForKey: @"email"];
-  if ([email length] > 0)
-    {
-      if ([fullName length] > 0)
-        fullEmail = [NSString stringWithFormat: @"%@ <%@>", fullName, email];
-      else
-        fullEmail = email;
-    }
-  else
-    {
-      NSLog (@"recipient not generated from record: %@", recipient);
-      fullEmail = nil;
-    }
-
-  return fullEmail;
-}
-
-static inline NSArray *
-MakeRecipientsList (NSArray *recipients)
-{
-  NSMutableArray *list;
-  NSUInteger count, max;
-  NSString *recipient;
-
-  max = [recipients count];
-  list = [NSMutableArray arrayWithCapacity: max];
-  for (count = 0; count < max; count++)
-    {
-      recipient = MakeRecipientString ([recipients objectAtIndex: count]);
-      if (recipient)
-        [list addObject: recipient];
-    }
-
-  return list;
-}
-
 static NSString *
 QuoteSpecials (NSString *address)
 {
@@ -531,6 +489,48 @@ QuoteSpecials (NSString *address)
     result = address;
 
   return result;
+}
+
+static inline NSString *
+MakeRecipientString (NSDictionary *recipient)
+{
+  NSString *fullName, *email, *fullEmail;
+
+  fullName = [recipient objectForKey: @"fullName"];
+  email = [recipient objectForKey: @"email"];
+  if ([email length] > 0)
+    {
+      if ([fullName length] > 0)
+        fullEmail = [NSString stringWithFormat: @"%@ <%@>", fullName, email];
+      else
+        fullEmail = email;
+    }
+  else
+    {
+      NSLog (@"recipient not generated from record: %@", recipient);
+      return  nil;
+    }
+
+  return QuoteSpecials(fullEmail);
+}
+
+static inline NSArray *
+MakeRecipientsList (NSArray *recipients)
+{
+  NSMutableArray *list;
+  NSUInteger count, max;
+  NSString *recipient;
+
+  max = [recipients count];
+  list = [NSMutableArray arrayWithCapacity: max];
+  for (count = 0; count < max; count++)
+    {
+      recipient = MakeRecipientString ([recipients objectAtIndex: count]);
+      if (recipient)
+        [list addObject: recipient];
+    }
+
+  return list;
 }
 
 static inline void

--- a/UI/MailerUI/UIxMailView.m
+++ b/UI/MailerUI/UIxMailView.m
@@ -306,9 +306,7 @@ static NSString *mailETag = nil;
       for (count = 0; !matchingIdentityEMail && count < max; count++)
         {
           address = [recipients objectAtIndex: count];
-          currentEMail = [NSString stringWithFormat: @"%@@%@",
-                                   [address mailbox],
-                                   [address host]];
+          currentEMail = [address baseEMail];
           if ([self _userHasEMail: currentEMail])
             {
               matchingIdentityEMail = currentEMail;


### PR DESCRIPTION
Recipients with underscore in their address (and no name) were displayed encoded both in Outlook and in the SOGo webmail. This PR (along with https://github.com/Zentyal/sope/pull/8 in sope) fixes this behaviour by using the updated `baseEMail` function when joining the `mailbox` and `host` fields and by adding quote marks to the email addresses in SOGo/OpenChange.