### PR TITLE
oc-rtf: no color table definition

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Enhancements
  - Improve sync speed from Outlook by non-reprocessing already downloaded unread mails
 
 Bug fixes
+ - Fix server side crash parsing rtf without color table
  - Weekly recurring events created in SOGo web interface are now shown in Outlook
  - Fix exception modifications import in recurrence series
  - Sent mails are not longer in Drafts folder using Outlook

--- a/OpenChange/RTFHandler.m
+++ b/OpenChange/RTFHandler.m
@@ -824,19 +824,19 @@ const unsigned short ansicpg874[256] = {
               int color_index;
               char *v;
 
+              if (!formattingOptions) continue;
+
               color_index = [[s substringFromIndex: 2] intValue];
-             
- 	      if (!formattingOptions)
-		continue;
- 
-              if (formattingOptions->color_index >= 0) // && color_index != formattingOptions->color_index)
+              colorDef = [colorTable colorDefAtIndex: color_index];
+              if (!colorDef) continue;
+
+              if (formattingOptions->color_index >= 0)
                 {
                   [_html appendBytes: "</font>"  length: 7];
                 }
-              
-              formattingOptions->color_index = color_index;              
-              colorDef = [colorTable colorDefAtIndex: color_index];
-              
+
+              formattingOptions->color_index = color_index;
+
               v = malloc(23*sizeof(char));
               memset(v, 0, 23);
               sprintf(v, "<font color=\"#%02x%02x%02x\">", colorDef->red, colorDef->green, colorDef->blue);


### PR DESCRIPTION
Be able to parse rtf files without `\colortbl` control word