### PR TITLE
oc: Empty ACL from a folder works with several users

### DIFF
--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -1745,10 +1745,12 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
   aclFolder = [self aclFolder];
 
-  users = [aclFolder aclUsers];
+  users = [[aclFolder aclUsers] copy];
   max = [users count];
   for (count = 0; count < max; count++)
     [aclFolder removeUserFromAcls: [users objectAtIndex: count]];
+
+  [users release];
 }
 
 - (int) modifyPermissions: (struct PermissionData *) permissions


### PR DESCRIPTION
The `[SOGoFolder:aclUsers]` returns a reference to a `NSArray`
which is being modified in the `for` loop making fail when
more than one user is in the ACL with `NSRangeException`.

NEWS message to include after merge in *Bug fixes* section:

```
 - Fix setting permissions for a folder with several users
```