### PR TITLE
oc-calendar: Store HTML from event description

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.h
+++ b/OpenChange/MAPIStoreAppointmentWrapper.h
@@ -134,6 +134,8 @@
                inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidTagBody: (void **) data
          inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidTagHtml: (void **) data
+         inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidLidIsRecurring: (void **) data
                     inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidLidRecurring: (void **) data

--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -1291,6 +1291,27 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
+- (int) getPidTagHtml: (void **) data
+         inMemCtx: (TALLOC_CTX *) memCtx
+{
+  CardElement *elem;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
+  NSString *html;
+
+  elem = [event uniqueChildWithTag: @"x-alt-desc"];
+  if (elem && [elem hasAttribute: @"fmttype" havingValue: @"text/html"])
+    {
+      html = [elem flattenedValuesForKey: @""];
+      if (html && [html length] > 0)
+        {
+          *data = [[html dataUsingEncoding: NSUTF8StringEncoding] asBinaryInMemCtx: memCtx];
+          rc = MAPISTORE_SUCCESS;
+        }
+    }
+
+  return rc;
+}
+
 - (int) getPidTagInternetCodepage: (void **) data
                          inMemCtx: (TALLOC_CTX *) memCtx
 {

--- a/OpenChange/iCalEvent+MAPIStore.m
+++ b/OpenChange/iCalEvent+MAPIStore.m
@@ -450,9 +450,16 @@
       value = [properties objectForKey: MAPIPropertyKey (PR_HTML)];
       if (value)
         {
+          /* Store the HTML in X-ALT-DESC with FMTTYPE to 'text/html' as
+             described in [MS-OXCICAL] Section 2.1.3.1.1.20.27 */
           value = [[NSString alloc] initWithData: value
                                         encoding: NSUTF8StringEncoding];
           [value autorelease];
+
+          CardElement *altDesc = [self uniqueChildWithTag: @"x-alt-desc"];
+          [altDesc setSingleValue: value forKey: @""];
+          [altDesc addAttribute: @"fmttype" value: @"text/html"];
+
           value = [value htmlToText];
         }
     }


### PR DESCRIPTION
According to [MS-OXCICAL] Section 2.1.3.1.1.20.27
it is stored in X-ALT-DESC tag with FMTTYPE attribute
set to "text/html". With that, we can export it as
ics and import properly in other Outlook without a problem.

This makes current supported RTF commands be maintained
between Outlook clients provided that in SOGo Webmail
plain text is only shown.

NEWS line:

   - Maintain Rich Text formatting in event description between Outlooks