### PR TITLE
oc-calendar: do not crash with invalid events

### DIFF
--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -181,6 +181,12 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
       else
         {
           origCalendar = [sogoObject calendar: YES secure: YES];
+          if (!origCalendar)
+            {
+              [self errorWithFormat: @"Incorrect calendar event %@. Empty message is created",
+                    [self url]];
+              return self;
+            }
           calendar = [origCalendar mutableCopy];
           masterEvent = [[calendar events] objectAtIndex: 0];
           [self _setupAttachmentParts];


### PR DESCRIPTION
A failure in parsing an ICS makes return a nil calendar
object. Instead of creating an appointment with nil
information which can lead to crashes like the one
generated creating PidLidCleanGlobalObjectId property.

We return an empty message with no information which is
taken into account in Outlook but not displayed like
in SOGo webmail does.

`NEWS` suggestion line in *Bug fixes* section:

  * Fix server-side crash with invalid events