### PR TITLE
Support for PidTagTransportMessageHeaders property

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 master
 ------
 
+New features
+ - Internet headers are now shown in Outlook
+
 Enhancements
  - Sharing request among different Outlook versions
  - Improve sync speed from Outlook by non-reprocessing already downloaded unread mails


### PR DESCRIPTION
This property is needed to show the 'Internet Headers' in Outlook.
Outlook show them in the properties dialog of a message.

The property is defined in [MS-OXOMSG] section 2.2.1.61.

The property is formed concatenating the mail message headers.
The headers are appended in no defined order, no order is defined in
the specification and I do not see any reason for the order used in
Outlook.

