### PR TITLE
oc-mail: Ensure we are creating folder to the right user

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -179,6 +179,12 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
     {
       nameInContainer = [NSString stringWithFormat: @"folder%@",
                                   [[folderName stringByEncodingImap4FolderName] asCSSIdentifier]];
+
+      /* it may be the operation is interleaved with operations
+         from other users having cached information in the thread
+         with the other user, so it'd better activate the user again here... */
+      [[self userContext] activateWithUser: [[[self userContext] woContext] activeUser]];
+
       newFolder = [SOGoMailFolderK objectWithName: nameInContainer
                                       inContainer: sogoObject];
       if ([newFolder create])


### PR DESCRIPTION
As it happened with dba17fb if we interleave requests
from different users while creating a folder we can
create the folder in other user's mailbox as latest
activeUser is the one from latest sogo_context_get_root_folder
call.

This is for me a lack of right design and a workaround
only fixing this issue but not the root cause.

Proposed `NEWS` line in **Bug fixes** section:

   * Does not create a mail folder in other user's mailbox