### PR TITLE
Soft deleted mail messages sync

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -519,7 +519,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
     *nextModseq;
   NSString *changeNumber, *uid, *messageKey;
   uint64_t lastModseqNbr;
-  EOQualifier *kvQualifier, *searchQualifier;
+  EOQualifier *searchQualifier;
   NSArray *uids, *changeNumbers;
   NSUInteger count, max;
   NSArray *fetchResults;
@@ -560,14 +560,11 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
     {
       lastModseqNbr = [lastModseq unsignedLongLongValue];
       nextModseq = [NSNumber numberWithUnsignedLongLong: lastModseqNbr + 1];
-      kvQualifier = [[EOKeyValueQualifier alloc]
+      searchQualifier = [[EOKeyValueQualifier alloc]
                                 initWithKey: @"modseq"
                            operatorSelector: EOQualifierOperatorGreaterThanOrEqualTo
                                       value: nextModseq];
-      searchQualifier = [[EOAndQualifier alloc]
-                          initWithQualifiers:
-                            kvQualifier, [self nonDeletedQualifier], nil];
-      [kvQualifier release];
+
       [searchQualifier autorelease];
     }
   else
@@ -595,7 +592,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 
       fetchResults
         = [(NSDictionary *) [sogoObject fetchUIDs: uids
-                                            parts: [NSArray arrayWithObject: @"modseq"]]
+                                            parts: [NSArray arrayWithObjects: @"modseq", @"flags", nil]]
                           objectForKey: @"fetch"];
 
       /* NOTE: we sort items manually because Cyrus does not properly sort
@@ -631,17 +628,22 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
           if (!lastModseq
               || ([lastModseq compare: modseq] == NSOrderedAscending))
             lastModseq = modseq;
+
+          if ([[result objectForKey: @"flags"] containsObject: @"deleted"])
+            [currentProperties setObject: changeNumber
+                                  forKey: @"SyncLastDeleteChangeNumber"];
         }
 
       [currentProperties setObject: lastModseq forKey: @"SyncLastModseq"];
       foundChange = YES;
     }
 
-  /* 2. we synchronise deleted UIDs */
+  /* 2. we synchronise expunged UIDs */
   if (initialLastModseq)
     {
       fetchResults = [(SOGoMailFolder *) sogoObject
                          fetchUIDsOfVanishedItems: lastModseqNbr];
+
       max = [fetchResults count];
 
       changeNumber = nil;
@@ -769,7 +771,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
   if (!messageEntry)
     {
       fetchResults = [(NSDictionary *) [sogoObject fetchUIDs: [NSArray arrayWithObject: messageUID]
-                                                       parts: [NSArray arrayWithObject: @"modseq"]]
+                                                       parts: [NSArray arrayWithObjects: @"modseq", @"flags", nil]]
                          objectForKey: @"fetch"];
       if ([fetchResults count] == 1)
         {
@@ -794,6 +796,11 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
           /* Store the changeNumber -> modseq mapping */
           mapping = [currentProperties objectForKey: @"VersionMapping"];
           [mapping setObject: modseq forKey: changeNumberStr];
+
+          /* Store the last deleted change number if it is soft-deleted */
+          if ([[result objectForKey: @"flags"] containsObject: @"deleted"])
+            [currentProperties setObject: changeNumberStr
+                                  forKey: @"SyncLastDeleteChangeNumber"];
 
           /* Save the message */
           [versionsMessage save];


### PR DESCRIPTION
1. Return soft-deleted mails while syncing
2. Include Deleted flagged messages on syncing the cache

The second one I don't know if it is required but increase accuracy to the cache values.

Use case: Moving messages around in one Outlook profile are correctly synced in other Outlook profile for the same account.
Use case: Drafts folder is correctly synced when sending mails leaving the folder empty when a message is successfully sent in all cases.

Tentative `NEWS` line could be already partial patch and this one:

    - Sent mails are not longer in Drafts folder using Outlook
    - Deleted mails are properly synced between Outlook profiles from the same account