### PR TITLE
oc: return last modified messages when sorted by PidMessageTagDeliveryTime

### DIFF
--- a/OpenChange/MAPIStoreCalendarMessageTable.m
+++ b/OpenChange/MAPIStoreCalendarMessageTable.m
@@ -182,6 +182,9 @@ static Class MAPIStoreCalendarMessageK = Nil;
                           forKey: MAPIPropertyKey (PR_CREATION_TIME)];
       [knownProperties setObject: @"c_uid"
                           forKey: MAPIPropertyKey (PR_OWNER_APPT_ID)];
+      /* Use by oxcfxics to sort the latest first */
+      [knownProperties setObject: @"c_lastmodified"
+                          forKey: MAPIPropertyKey (PidTagMessageDeliveryTime)];
     }
 
   return [knownProperties objectForKey: MAPIPropertyKey (property)];

--- a/OpenChange/MAPIStoreContactsMessageTable.m
+++ b/OpenChange/MAPIStoreContactsMessageTable.m
@@ -220,6 +220,9 @@ static Class MAPIStoreContactsMessageK, NGMailAddressK, NSDataK, NSStringK;
 			  forKey: MAPIPropertyKey (PidTagSubject)];
       [knownProperties setObject: @"c_cn"
 			  forKey: MAPIPropertyKey (PidTagNormalizedSubject)];
+      /* Use by oxcfxics to sort the latest first */
+      [knownProperties setObject: @"c_lastmodified"
+                          forKey: MAPIPropertyKey (PidTagMessageDeliveryTime)];
     }
 
   return [knownProperties objectForKey: MAPIPropertyKey (property)];

--- a/OpenChange/MAPIStoreTasksMessageTable.m
+++ b/OpenChange/MAPIStoreTasksMessageTable.m
@@ -157,6 +157,9 @@ static Class MAPIStoreTasksMessageK = Nil;
                           forKey: MAPIPropertyKey (PidLidTaskDueDate)];
       [knownProperties setObject: @"c_creationdate"
                           forKey: MAPIPropertyKey (PidLidTaskOrdinal)];
+      /* Use by oxcfxics to sort the latest first */
+      [knownProperties setObject: @"c_lastmodified"
+                          forKey: MAPIPropertyKey (PidTagMessageDeliveryTime)];
     }
 
   return [knownProperties objectForKey: MAPIPropertyKey (property)];


### PR DESCRIPTION
This change is required as oxcfxics is asking for sorting
using this property.

We fake this property on GCS folders (Tasks, Calendar, Contacts)
using c_lastmodified column.

Suggestion for `NEWS` file in **Enhancements** section:

   - Events, tasks and contacts are synced in reverse chronological order