### PR TITLE
oc: Search for properties in a SOGoMAPIDB object now works

### DIFF
--- a/SoObjects/SOGo/EOQualifier+SOGoCacheObject.m
+++ b/SoObjects/SOGo/EOQualifier+SOGoCacheObject.m
@@ -125,6 +125,11 @@ typedef BOOL (*EOComparator) (id, SEL, id);
     finalKey = @"";
 
   propValue = [properties objectForKey: finalKey];
+  /* sogo-openchange library stores the properties as NSString keys
+     and we have to check if the property exists using the NSString */
+  if (!propValue && [key isKindOfClass: [NSString class]])
+    propValue = [properties objectForKey: key];
+
   comparator = (EOComparator) [propValue methodForSelector: operator];
 
   return (comparator ? comparator (propValue, operator, value) : NO);


### PR DESCRIPTION
sogo-openchange library stores the properties as NSString keys
and the search function casts the values to NSNumber, which it may
be valid for other parts but not for this library.

The real fix would be to store the property keys as NSNumbers as
they are uint32_t at the end. However, this may lead to a great
refactor in the library.

With this fix, we can match the search for a property in a
MAPIStoreFallback folder, such as Notes or Deleted Items, or
MAPIStoreFolder properties (ie: search for a subfolder) or
for MAPIStoreFAIMessages in a folder.