### PR TITLE
oc: Enforce the folder creation mapping when the FID exists

### DIFF
--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -402,7 +402,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
              withRow: (struct SRow *) aRow
               andFID: (uint64_t) fid
 {
-  int rc = MAPISTORE_SUCCESS;
+  BOOL mapped;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   MAPIStoreMapping *mapping;
   NSString *baseURL, *childURL, *folderKey;
   MAPIStoreFolder *childFolder;
@@ -430,7 +431,12 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
               childURL = [NSString stringWithFormat: @"%@%@/",
                                    baseURL,
                                    [folderKey stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]];
-              [mapping registerURL: childURL withID: fid];
+
+              mapped = [mapping registerURL: childURL withID: fid];
+              if (!mapped)
+                /* Enforce the creation if the backend does know the fid */
+                [mapping updateURL: childURL withID: fid];
+
               childFolder = [self lookupFolder: folderKey];
               if (childFolder)
                 {

--- a/OpenChange/MAPIStoreMapping.h
+++ b/OpenChange/MAPIStoreMapping.h
@@ -60,6 +60,8 @@
                     andFlags: (uint8_t) flags;
 - (void) updateID: (uint64_t) idNbr
           withURL: (NSString *) urlString;
+- (BOOL) updateURL: (NSString *) urlString
+            withID: (uint64_t) idNbr;
 
 @end
 

--- a/OpenChange/MAPIStoreMapping.m
+++ b/OpenChange/MAPIStoreMapping.m
@@ -227,12 +227,32 @@ MAPIStoreMappingKeyFromId (uint64_t idNbr)
     }
 }
 
+- (BOOL) updateURL: (NSString *) urlString
+            withID: (uint64_t) idNbr
+{
+  BOOL rc = NO;
+  uint64_t oldIDNbr;
+
+  oldIDNbr = [self idFromURL: urlString];
+  if (oldIDNbr)
+    {
+      [self logWithFormat: @"Updating URL: %@ with id %.16"PRIx64" from old id %.16"PRIx64,
+            urlString, idNbr, oldIDNbr];
+      [self unregisterURLWithID: oldIDNbr];
+      [self registerURL: urlString
+                 withID: idNbr];
+      rc = YES;
+    }
+
+  return rc;
+}
+
 - (BOOL) registerURL: (NSString *) urlString
               withID: (uint64_t) idNbr
 {
   NSString *oldURL;
   uint64_t oldIdNbr;
-  bool rc, softDeleted;
+  bool softDeleted;
 
   oldURL = [self urlFromID: idNbr];
   if (oldURL != NULL)
@@ -257,7 +277,6 @@ MAPIStoreMappingKeyFromId (uint64_t idNbr)
     }
   else
     {
-      rc = YES;
       // [self logWithFormat: @"registered url '%@' with id %lld (0x%.16"PRIx64")",
       //       urlString, idNbr, idNbr];
 
@@ -266,7 +285,7 @@ MAPIStoreMappingKeyFromId (uint64_t idNbr)
                          idNbr, [urlString UTF8String]);
     }
 
-  return rc;
+  return YES;
 }
 
 - (void) registerURLs: (NSArray *) urlStrings


### PR DESCRIPTION
We believe the folder ID OpenChange is sending us is new
and we keep the indexing database properly updated.

Although the solution is not elegant, this could avoid
inconsistencies between what the client stores and the
relation in the MAPIStore backend.