### PR TITLE
Multidomain cache tables

### DIFF
--- a/ActiveSync/SOGoActiveSyncDispatcher.m
+++ b/ActiveSync/SOGoActiveSyncDispatcher.m
@@ -2644,7 +2644,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
              parts in this url. We strip the '-' character in case we have
              this in the domain part - like foo@bar-zot.com */
           ocFSTableName = [NSMutableString stringWithFormat: @"sogo_cache_folder_%@",
-                                           [[user loginInDomain] asCSSIdentifier]];
+                                           [[user login] asCSSIdentifier]];
           [ocFSTableName replaceOccurrencesOfString: @"-"
                                          withString: @"_"
                                             options: 0

--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -311,9 +311,9 @@ static NSMapTable *contextsTable = nil;
              parts in this url. We strip the '-' character in case we have
              this in the domain part - like foo@bar-zot.com */
           ocFSTableName = [NSString stringWithFormat: @"sogo_cache_folder_%@",
-                                    [[[user loginInDomain] asCSSIdentifier] 
-                                      stringByReplacingOccurrencesOfString: @"-"
-                                                                withString: @"_"]];
+                                    [[[user login] asCSSIdentifier]
+                                     stringByReplacingOccurrencesOfString: @"-"
+                                                               withString: @"_"]];
           [parts replaceObjectAtIndex: 4 withObject: ocFSTableName];
           folderTableURL
             = [NSURL URLWithString: [parts componentsJoinedByString: @"/"]];

--- a/Tools/SOGoToolManageEAS.m
+++ b/Tools/SOGoToolManageEAS.m
@@ -142,7 +142,7 @@ typedef enum
              parts in this url. We strip the '-' character in case we have
              this in the domain part - like foo@bar-zot.com */
           ocFSTableName = [NSMutableString stringWithFormat: @"sogo_cache_folder_%@",
-                                           [[user loginInDomain] asCSSIdentifier]];
+                                           [[user login] asCSSIdentifier]];
           [ocFSTableName replaceOccurrencesOfString: @"-"
                                          withString: @"_"
                                             options: 0


### PR DESCRIPTION
Use full login for `sogo_cache_folder` tables.

So when multidomain is enabled we will have tables like `sogo_cache_folder_user_A_domain_D_com` instead of just `sogo_cache_folder_user`

If multidomain is disabled the folders will still be like `sogo_cache_folder_user`