### PR TITLE
oc: Fix internal EntryIds properties on multidomain

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -264,7 +264,7 @@ static NSCharacterSet *hexCharacterSet = nil;
 
           if (contactInfos)
             {
-              username = [contactInfos objectForKey: @"c_uid"];
+              username = [contactInfos objectForKey: @"sAMAccountName"];
               recipient->username = [username asUnicodeInMemCtx: msgData];
               entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
             }
@@ -365,7 +365,7 @@ static NSCharacterSet *hexCharacterSet = nil;
 
         if (contactInfos)
           {
-            username = [contactInfos objectForKey: @"c_uid"];
+            username = [contactInfos objectForKey: @"sAMAccountName"];
             recipient->username = [username asUnicodeInMemCtx: msgData];
             entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
           }
@@ -931,7 +931,7 @@ static NSCharacterSet *hexCharacterSet = nil;
   contactInfos = [mgr contactInfosForUserWithUIDorEmail: email];
   if (contactInfos)
     {
-      username = [contactInfos objectForKey: @"c_uid"];
+      username = [contactInfos objectForKey: @"sAMAccountName"];
       entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
     }
   else

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -803,7 +803,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
       contactInfos = [mgr contactInfosForUserWithUIDorEmail: email];
       if (contactInfos)
         {
-          username = [contactInfos objectForKey: @"c_uid"];
+          username = [contactInfos objectForKey: @"sAMAccountName"];
           samCtx = [[self context] connectionInfo]->sam_ctx;
           entryId = MAPIStoreInternalEntryId (samCtx, username);
         }
@@ -1501,10 +1501,10 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
                   if ([cn length] == 0)
                     cn = email;
                   contactInfos = [mgr contactInfosForUserWithUIDorEmail: email];
-                  
+
                   if (contactInfos)
                     {
-                      username = [contactInfos objectForKey: @"c_uid"];
+                      username = [contactInfos objectForKey: @"sAMAccountName"];
                       recipient->username = [username asUnicodeInMemCtx: msgData];
                       entryId = MAPIStoreInternalEntryId (samCtx, username);
                     }

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -386,7 +386,7 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
           contactInfos = [mgr contactInfosForUserWithUIDorEmail: email];
           if (contactInfos)
             {
-              username = [contactInfos objectForKey: @"c_uid"];
+              username = [contactInfos objectForKey: @"sAMAccountName"];
               recipient->username = [username asUnicodeInMemCtx: msgData];
               entryId = MAPIStoreInternalEntryId (samCtx, username);
             }

--- a/OpenChange/MAPIStoreSamDBUtils.m
+++ b/OpenChange/MAPIStoreSamDBUtils.m
@@ -96,8 +96,11 @@ MAPIStoreInternalEntryId (struct ldb_context *samCtx, NSString *username)
       [entryId appendUInt8: 0]; // end of string
     }
   else
-    entryId = nil;
- 
+    {
+      NSLog (@"Error trying to generate EntryId for `%@`", username);
+      entryId = nil;
+    }
+
   return entryId;
 }
 

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -664,7 +664,7 @@ static Class NSNullK;
 //
 //
 - (void) _fillContactInfosForUser: (NSMutableDictionary *) currentUser
-		   withUIDorEmail: (NSString *) uid
+                   withUIDorEmail: (NSString *) uid
                          inDomain: (NSString *) domain
 {
   NSString *sourceID, *cn, *c_domain, *c_uid, *c_imaphostname, *c_imaplogin, *c_sievehostname;
@@ -685,12 +685,11 @@ static Class NSNullK;
   c_sievehostname = nil;
 
   [currentUser setObject: [NSNumber numberWithBool: YES]
-	       forKey: @"CalendarAccess"];
+                  forKey: @"CalendarAccess"];
   [currentUser setObject: [NSNumber numberWithBool: YES]
-	       forKey: @"MailAccess"];
+                  forKey: @"MailAccess"];
 
-  sogoSources = [[self authenticationSourceIDsInDomain: domain]
-                  objectEnumerator];
+  sogoSources = [[self authenticationSourceIDsInDomain: domain] objectEnumerator];
   userEntry = nil;
   while (!userEntry && (sourceID = [sogoSources nextObject]))
     {
@@ -698,44 +697,49 @@ static Class NSNullK;
       userEntry = [currentSource lookupContactEntryWithUIDorEmail: uid
                                                          inDomain: domain];
       if (userEntry)
-	{
+        {
           [currentUser setObject: sourceID forKey: @"SOGoSource"];
-	  if (!cn)
-	    cn = [userEntry objectForKey: @"c_cn"];
-	  if (!c_uid)
-	    c_uid = [userEntry objectForKey: @"c_uid"];
+          if (!cn)
+            cn = [userEntry objectForKey: @"c_cn"];
+          if (!c_uid)
+            c_uid = [userEntry objectForKey: @"c_uid"];
           if (!c_domain)
             c_domain = [userEntry objectForKey: @"c_domain"];
-	  c_emails = [userEntry objectForKey: @"c_emails"];
-	  if ([c_emails count])
-	    [emails addObjectsFromArray: c_emails];
-	  if (!c_imaphostname)
-	    c_imaphostname = [userEntry objectForKey: @"c_imaphostname"];
+          c_emails = [userEntry objectForKey: @"c_emails"];
+          if ([c_emails count])
+            [emails addObjectsFromArray: c_emails];
+          if (!c_imaphostname)
+            c_imaphostname = [userEntry objectForKey: @"c_imaphostname"];
           if (!c_imaplogin)
             c_imaplogin = [userEntry objectForKey: @"c_imaplogin"];
           if (!c_sievehostname)
             c_sievehostname = [userEntry objectForKey: @"c_sievehostname"];
-	  access = [[userEntry objectForKey: @"CalendarAccess"] boolValue];
-	  if (!access)
-	    [currentUser setObject: [NSNumber numberWithBool: NO]
-			 forKey: @"CalendarAccess"];
-	  access = [[userEntry objectForKey: @"MailAccess"] boolValue];
-	  if (!access)
-	    [currentUser setObject: [NSNumber numberWithBool: NO]
-			 forKey: @"MailAccess"];
-	  
-	  // We check if it's a group
+          access = [[userEntry objectForKey: @"CalendarAccess"] boolValue];
+          if (!access)
+            [currentUser setObject: [NSNumber numberWithBool: NO]
+                            forKey: @"CalendarAccess"];
+          access = [[userEntry objectForKey: @"MailAccess"] boolValue];
+          if (!access)
+            [currentUser setObject: [NSNumber numberWithBool: NO]
+                            forKey: @"MailAccess"];
+
+          // We check if it's a group
           isGroup = [userEntry objectForKey: @"isGroup"];
           if (isGroup)
             [currentUser setObject: isGroup forKey: @"isGroup"];
 
-	  // We also fill the resource attributes, if any
-	  if ([userEntry objectForKey: @"isResource"])
-	    [currentUser setObject: [userEntry objectForKey: @"isResource"]
-			 forKey: @"isResource"];
-	  if ([userEntry objectForKey: @"numberOfSimultaneousBookings"])
-	    [currentUser setObject: [userEntry objectForKey: @"numberOfSimultaneousBookings"]
-			 forKey: @"numberOfSimultaneousBookings"];
+          // We also fill the resource attributes, if any
+          if ([userEntry objectForKey: @"isResource"])
+            [currentUser setObject: [userEntry objectForKey: @"isResource"]
+                            forKey: @"isResource"];
+          if ([userEntry objectForKey: @"numberOfSimultaneousBookings"])
+            [currentUser setObject: [userEntry objectForKey: @"numberOfSimultaneousBookings"]
+                            forKey: @"numberOfSimultaneousBookings"];
+
+          // This is Active Directory specific attribute (needed on OpenChange/* layer)
+          if ([userEntry objectForKey: @"samaccountname"])
+            [currentUser setObject: [userEntry objectForKey: @"samaccountname"]
+                            forKey: @"sAMAccountName"];
         }
     }
 
@@ -745,7 +749,7 @@ static Class NSNullK;
     c_uid = @"";
   if (!c_domain)
     c_domain = @"";
-  
+
   if (c_imaphostname)
     [currentUser setObject: c_imaphostname forKey: @"c_imaphostname"];
   if (c_imaplogin)


### PR DESCRIPTION
All this basically is to make it work on multidomain environment the `Reply all` functionality of emails but I'm sure there are more use cases as an Outlook client that don't work nowadays without this patch.

Suggested message for `NEWS`, under bugfix seciton:

* Outlook clients can use reply all functionality on multidomain environment

I don't know how to put into words properly zinc environment / multidomain environment / email adress as login.

More info on commit message but basically it was that we were using `user` instead of `user@domain.com` in several places.