### PR TITLE
oc-calendar: Fix recipient type for invitations

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -273,7 +273,7 @@ static NSCharacterSet *hexCharacterSet = nil;
               recipient->username = NULL;
               entryId = MAPIStoreExternalEntryId (cn, email);
             }
-          recipient->type = MAPI_TO;
+          recipient->type = [[person role] isEqualToString: @"OPT-PARTICIPANT"] ? MAPI_CC : MAPI_TO;
 
           /* properties */
           p = 0;
@@ -283,7 +283,7 @@ static NSCharacterSet *hexCharacterSet = nil;
           // PR_OBJECT_TYPE = MAPI_MAILUSER (see MAPI_OBJTYPE)
           recipient->data[p] = MAPILongValue (msgData, MAPI_MAILUSER);
           p++;
-          
+
           // PR_DISPLAY_TYPE = DT_MAILUSER (see MS-NSPI)
           recipient->data[p] = MAPILongValue (msgData, 0);
           p++;
@@ -383,7 +383,7 @@ static NSCharacterSet *hexCharacterSet = nil;
         // PR_OBJECT_TYPE = MAPI_MAILUSER (see MAPI_OBJTYPE)
         recipient->data[p] = MAPILongValue (msgData, MAPI_MAILUSER);
         p++;
-          
+
         // PR_DISPLAY_TYPE = DT_MAILUSER (see MS-NSPI)
         recipient->data[p] = MAPILongValue (msgData, 0);
         p++;


### PR DESCRIPTION
Take into account optional attendees setting the recipient
type to MAPI_CC when they have the iCal role set to OPT-PARTICIPANT
instead of harding always MAPI_TO (required) as was done before.

This is a complementary fix for: #108

NEWS message to include after merge in *Bug fixes* section:

```
 - Optional attendes are now shown as optional in calendar invitations
```