### PR TITLE
oc-mail: Support restricitions on name for MAPIStoreMailFolderTable

### DIFF
--- a/OpenChange/GNUmakefile
+++ b/OpenChange/GNUmakefile
@@ -100,6 +100,7 @@ $(SOGOBACKEND)_OBJC_FILES += \
 	MAPIStoreMailAttachment.m \
 	MAPIStoreMailContext.m \
 	MAPIStoreMailFolder.m \
+	MAPIStoreMailFolderTable.m \
 	MAPIStoreMailMessage.m \
 	MAPIStoreMailVolatileMessage.m \
 	MAPIStoreMailMessageTable.m \

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -52,6 +52,7 @@
 #import "MAPIStoreFAIMessage.h"
 #import "MAPIStoreMailContext.h"
 #import "MAPIStoreMailMessage.h"
+#import "MAPIStoreMailFolderTable.h"
 #import "MAPIStoreMailMessageTable.h"
 #import "MAPIStoreMapping.h"
 #import "MAPIStoreTypes.h"
@@ -152,6 +153,11 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
 {
   [self synchroniseCache];
   return [MAPIStoreMailMessageTable tableForContainer: self];
+}
+
+- (MAPIStoreFolderTable *) folderTable
+{
+  return [MAPIStoreMailFolderTable tableForContainer: self];
 }
 
 - (enum mapistore_error) createFolder: (struct SRow *) aRow
@@ -359,12 +365,17 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
 - (NSArray *) folderKeysMatchingQualifier: (EOQualifier *) qualifier
                          andSortOrderings: (NSArray *) sortOrderings
 {
+  NSArray *filteredSubfolderKeys;
   NSMutableArray *subfolderKeys;
+  NSMutableArray *subfolderKeysQualifying;
+  NSString *subfolderKey;
+  NSUInteger count, max;
 
   if ([self ensureFolderExists])
     {
+      /* Only folder name can be used as qualifier key */
       if (qualifier)
-        [self errorWithFormat: @"qualifier is not used for folders"];
+        [self warnWithFormat: @"qualifier is only used for folders with name"];
       if (sortOrderings)
         [self errorWithFormat: @"sort orderings are not used for folders"];
       
@@ -372,6 +383,31 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
       [subfolderKeys autorelease];
 
       [self _cleanupSubfolderKeys: subfolderKeys];
+
+      if (qualifier)
+        {
+          subfolderKeysQualifying = [NSMutableArray array];
+          max = [subfolderKeys count];
+          for (count = 0; count < max; count++) {
+            subfolderKey = [subfolderKeys objectAtIndex: count];
+            /* Remove "folder" prefix */
+            subfolderKey = [subfolderKey substringFromIndex: 6];
+            subfolderKey = [[subfolderKey fromCSSIdentifier] stringByDecodingImap4FolderName];
+            [subfolderKeysQualifying addObject: [NSDictionary dictionaryWithObject: subfolderKey
+                                                                            forKey: @"name"]];
+          }
+          filteredSubfolderKeys = [subfolderKeysQualifying filteredArrayUsingQualifier: qualifier];
+
+          max = [filteredSubfolderKeys count];
+          subfolderKeys = [NSMutableArray arrayWithCapacity: max];
+          for (count = 0; count < max; count++)
+            {
+              subfolderKey = [[filteredSubfolderKeys objectAtIndex: count] valueForKey: @"name"];
+              subfolderKey = [NSString stringWithFormat: @"folder%@", [[subfolderKey stringByEncodingImap4FolderName] asCSSIdentifier]];
+              [subfolderKeys addObject: subfolderKey];
+            }
+
+        }
     }
   else
     subfolderKeys = nil;

--- a/OpenChange/MAPIStoreMailFolderTable.h
+++ b/OpenChange/MAPIStoreMailFolderTable.h
@@ -1,0 +1,31 @@
+/* MAPIStoreMailFolderTable.h - this file is part of SOGo
+ *
+ * Copyright (C) 2015 Enrique J. Hernández
+ *
+ * Author: Enrique J. Hernández <ejhernandez@zentyal.com>
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef MAPISTOREMAILFOLDERTABLE_H
+#define MAPISTOREMAILFOLDERTABLE_H
+
+#import "MAPIStoreFolderTable.h"
+
+@interface MAPIStoreMailFolderTable : MAPIStoreFolderTable
+@end
+
+#endif /* MAPISTOREMAILFOLDERTABLE_H */

--- a/OpenChange/MAPIStoreMailFolderTable.m
+++ b/OpenChange/MAPIStoreMailFolderTable.m
@@ -1,0 +1,42 @@
+/* MAPIStoreMailFolderTable.m - this file is part of SOGo
+ *
+ * Copyright (C) 2015 Enrique J. Hernández
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#import <Foundation/NSString.h>
+
+#import "MAPIStoreMailFolderTable.h"
+#import "MAPIStoreTypes.h"
+
+@implementation MAPIStoreMailFolderTable
+
+- (NSString *) backendIdentifierForProperty: (enum MAPITAGS) property
+{
+  switch(property)
+    {
+    case PR_DISPLAY_NAME:
+    case PR_DISPLAY_NAME_UNICODE:
+      return @"name";
+    default:
+      return nil;
+    }
+}
+
+
+@end
+


### PR DESCRIPTION
This allows us to search for a subfolder in a mail
folder successfully. This is happening ie on folder creation.

I see this not relevant from the user's point of view as you can see the folders that exists before trying to create a new one with the same name. This is only useful by now for functional testing. Correct me if I'm wrong.