### PR TITLE
oc-calendar: Interpret dates of all-day events in floating time

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -1461,8 +1461,6 @@ static NSCharacterSet *hexCharacterSet = nil;
   firstStartDate = [event firstRecurrenceStartDate];
   if (firstStartDate)
     {
-      [firstStartDate setTimeZone: timeZone];
-
       arp = talloc_zero (NULL, struct AppointmentRecurrencePattern);
       [rule fillRecurrencePattern: &arp->RecurrencePattern
                         withEvent: event
@@ -1472,6 +1470,12 @@ static NSCharacterSet *hexCharacterSet = nil;
       arp->WriterVersion2 = 0x00003008; /* 0x3008 for compatibility with
                                            ol2003 */
 
+      /* All day events' dates are specified in floating time
+         ([MS-OXCICAL] 2.1.3.1.1.20.10). The StartTimeOffset and EndTimeOffset
+	 fields are relative to midnight of those days ([MS-OXOCAL] 2.2.1.44.5),
+	 so no time zone adjustment is needed */
+      if (![event isAllDay])
+        [firstStartDate setTimeZone: timeZone];
       startMinutes = ([firstStartDate hourOfDay] * 60
                       + [firstStartDate minuteOfHour]);
       arp->StartTimeOffset = startMinutes;


### PR DESCRIPTION
All-day events' dates are stored in floating time (withouth time zone information), so when time zone information is required we have to extract it from the user's context. Some properties, on the other hand, are relative to the user's time zone, so no extra computations are required.

* https://github.com/Zentyal/sogo/commit/7e89c43919a258dc4f41d309b58408dab307b6d5 Fixes the way all-day recurring events are displayed in OL (they were displayed from 2:00 to 2:00 of the following day)
* https://github.com/Zentyal/sogo/commit/ebe2a466e7ac3d6aa0f10befc9367555224ac752 Doesn't produce any visible behaviour change, but it corrects a mismatch between the specifications and the code.

Suggested NEWS line:
`Recurrent all day events are now shown properly in Outlook` 