### PR TITLE
oc-mail: Flush IMAP hierarchy cache to update Outlook folders

### DIFF
--- a/OpenChange/MAPIStoreMailContext.m
+++ b/OpenChange/MAPIStoreMailContext.m
@@ -146,6 +146,9 @@ MakeDisplayFolderName (NSString *folderName)
       DLIST_ADD_END (firstContext, context, void);
     }
 
+  /* FIXME: Flush any cache before retrieving the hierarchy */
+  [accountFolder flushMailCaches];
+
   secondaryFolders = [[accountFolder toManyRelationshipKeysWithNamespaces: NO]
                        mutableCopy];
   [secondaryFolders autorelease];

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -368,6 +368,11 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
       if (sortOrderings)
         [self errorWithFormat: @"sort orderings are not used for folders"];
       
+      /* FIXME: Flush any cache before retrieving the hierarchy, this
+         slows things down but it is safer */
+      if (!qualifier)
+        [sogoObject flushMailCaches];
+
       subfolderKeys = [[sogoObject toManyRelationshipKeys] mutableCopy];
       [subfolderKeys autorelease];
 


### PR DESCRIPTION
This fixes two scenarios:

* An IMAP subfolder has updated its hierarchy when it is asked
  to be synchronised
* An IMAP root folder is created on Outlook when you logon. OpenChange
  changes are required to be refreshed on synchronisation.

I'd add this in **Enhancements** section of `NEWS` file as it can be workarounded by restarting samba daemon. These two lines should be added:

* Mail subfolders created in WebMail are created when Outlook synchronises.
* Mail root folder created in WebMail (same level INBOX) are created on Outlook logon.