### PR TITLE
oc-calendar: Do not skip submit of meeting request and response messages

### DIFF
--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -1054,7 +1054,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
   id <SOGoAuthenticator> authenticator;
 
   msgClass = [properties objectForKey: MAPIPropertyKey (PidTagMessageClass)];
-  if ([msgClass isEqualToString: @"IPM.Note"] || [msgClass isEqualToString: @"IPM.Sharing"]) /* we skip invitation replies */
+  if ([msgClass isEqualToString: @"IPM.Note"] || [msgClass isEqualToString: @"IPM.Sharing"] || [msgClass hasPrefix: @"IPM.Schedule.Meeting"])
     {
       /* send mail */
 


### PR DESCRIPTION
When the PidTagMessageClass is IPM.Schedule.Meeting.Request, it is ignored
as only messages with class IPM.Note or IPM.Sharing were taken into account.

There is a a comment that says that the purpose of the check is to skip
invitation replies, that may be ok for some reason, because replies have a
different class like IPM.Schedule.Meeting.Resp.Pos or IPM.Schedule.Meeting.Resp.Neg,
but requests according to that comment, requests should not be ignored.

Not sure why in some cases this has worked without this change, but at least
now seems pretty easy to reproduce it, and this seems to fix the issue.