### PR TITLE
oc-calendar: Fix property values of invitation responses

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -35,6 +35,7 @@
 {
   BOOL headerSetup;
   BOOL mailIsEvent;
+  BOOL mailIsMeetingRequest;
   BOOL mailIsSharingObject;
   NSString *mimeKey;
   NSString *headerCharset;


### PR DESCRIPTION
The value of `PidTagResponseRequested` property in the invitation mail
wasn't being set properly, while the `PidTagReplyRequested` property
wasn't being set at all. This caused invitation response mails not to be
sent. Both properties are expected to be `true`.

Suggested NEWS line:

`Event invitation response mails are now sent`