### PR TITLE
oc-calendar: Fix regression on PidLidAppointmentTimeZoneDefinitionStartDisplay

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -2080,6 +2080,8 @@ ReservedBlockEE2Size: 00 00 00 00
     icalTZ = [iCalTimeZone timeZoneForName: [timeZone timeZoneName]];
   else if ([event isRecurrent])
     icalTZ = [(iCalDateTime *) [event firstChildWithTag: @"dtstart"] timeZone];
+  else
+    icalTZ = nil;
 
   if (icalTZ)
     {


### PR DESCRIPTION
Introduced by ebe2a466e7 in PR #132 when the event is not
all day neither recurrent one.

The fix is just to initialise to nil when it is a normal event
and it returns NOT_FOUND for this property.

No update in `NEWS` as it is a fix on a one of the unreleased changes.