### PR TITLE
Avoid reading emails from other domains (info@foo vs info@bar)

### DIFF
--- a/SoObjects/SOGo/SOGoUserFolder.m
+++ b/SoObjects/SOGo/SOGoUserFolder.m
@@ -427,7 +427,8 @@
         {
           currentUser = [users objectAtIndex: i];
           field = [currentUser objectForKey: @"c_uid"];
-          if (enableDomainBasedUID)
+          if (enableDomainBasedUID &&
+              [field rangeOfString: @"@"].location == NSNotFound)
             field = [NSString stringWithFormat: @"%@@%@", field, domain];
           if (![field isEqualToString: login])
             {

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -622,7 +622,8 @@ static Class NSNullK;
       // internal cache.
       [currentUser setObject: [newPassword asSHA1String] forKey: @"password"];
       sd = [SOGoSystemDefaults sharedSystemDefaults];
-      if ([sd enableDomainBasedUID])
+      if ([sd enableDomainBasedUID] &&
+          [login rangeOfString: @"@"].location == NSNotFound)
         userLogin = [NSString stringWithFormat: @"%@@%@", login, domain];
       else
         userLogin = login;

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -488,7 +488,8 @@ static Class NSNullK;
               grace: (int *) _grace
            useCache: (BOOL) useCache
 {
-  NSMutableDictionary *currentUser, *failedCount;
+  NSMutableDictionary *currentUser;
+  NSDictionary *failedCount;
   NSString *dictPassword, *username, *jsonUser;
   SOGoSystemDefaults *dd;
   BOOL checkOK;

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -362,6 +362,7 @@ static Class NSNullK;
   NSDictionary *contactInfos;
   NSString *login;
   SOGoDomainDefaults *dd;
+  SOGoSystemDefaults *sd;
 
   contactInfos = [self contactInfosForUserWithUIDorEmail: uid
                                                 inDomain: domain];
@@ -372,10 +373,22 @@ static Class NSNullK;
         dd = [SOGoDomainDefaults defaultsForDomain: domain];
       else
         dd = [SOGoSystemDefaults sharedSystemDefaults];
-      
-      login = [dd forceExternalLoginWithEmail] ? [self getEmailForUID: uid] : uid;
+
+      if ([dd forceExternalLoginWithEmail])
+        {
+          sd = [SOGoSystemDefaults sharedSystemDefaults];
+          if ([sd enableDomainBasedUID])
+            // On multidomain environment we must use uid@domain
+            // for getEmailForUID method
+            login = [NSString stringWithFormat: @"%@@%@", uid, domain];
+          else
+            login = uid;
+          login = [self getEmailForUID: login];
+        }
+      else
+        login = uid;
     }
-  
+
   return login;
 }
 

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -492,23 +492,17 @@ static Class NSNullK;
   NSString *dictPassword, *username, *jsonUser;
   SOGoSystemDefaults *dd;
   BOOL checkOK;
- 
-  // We check for cached passwords. If the entry is cached, we 
-  // check this immediately. If not, we'll go directly at the
-  // authentication source and try to validate there, then cache it.
-  if (*_domain != nil)
+
+  if (*_domain && [_login rangeOfString: @"@"].location == NSNotFound)
     username = [NSString stringWithFormat: @"%@@%@", _login, *_domain];
   else
     username = _login;
 
-  failedCount = [[SOGoCache sharedCache] failedCountForLogin: username];
-  dd = [SOGoSystemDefaults sharedSystemDefaults];
-
-  //
   // We check the fail count per user in memcache (per server). If the
   // fail count reaches X in Y minutes, we deny immediately the
   // authentications for Z minutes
-  //
+  failedCount = [[SOGoCache sharedCache] failedCountForLogin: username];
+  dd = [SOGoSystemDefaults sharedSystemDefaults];
   if (failedCount)
     {
       unsigned int current_time, start_time, delta, block_time;
@@ -534,7 +528,9 @@ static Class NSNullK;
         }
     }
 
-
+  // We check for cached passwords. If the entry is cached, we
+  // check this immediately. If not, we'll go directly at the
+  // authentication source and try to validate there, then cache it.
   jsonUser = [[SOGoCache sharedCache] userAttributesForLogin: username];
   currentUser = [jsonUser objectFromJSONString];
   dictPassword = [currentUser objectForKey: @"password"];

--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -776,24 +776,20 @@ static Class NSNullK;
            withLogin: (NSString *) login
 {
   NSEnumerator *emails;
-  NSString *key;
-  
-  [[SOGoCache sharedCache]
-        setUserAttributes: [newUser jsonRepresentation]
-                 forLogin: login];
+  NSString *key, *user_json;
+
+  user_json = [newUser jsonRepresentation];
+  [[SOGoCache sharedCache] setUserAttributes: user_json
+                                    forLogin: login];
   if (![newUser isKindOfClass: NSNullK])
     {
-      key = [newUser objectForKey: @"c_uid"];
-      if (key && ![key isEqualToString: login])
-        [[SOGoCache sharedCache]
-            setUserAttributes: [newUser jsonRepresentation]
-                     forLogin: key];
-
       emails = [[newUser objectForKey: @"emails"] objectEnumerator];
       while ((key = [emails nextObject]))
-        [[SOGoCache sharedCache]
-            setUserAttributes: [newUser jsonRepresentation]
-                     forLogin: key];
+        {
+          if (![key isEqualToString: login])
+            [[SOGoCache sharedCache] setUserAttributes: user_json
+                                              forLogin: key];
+        }
     }
 }
 

--- a/UI/MainUI/SOGoRootPage.m
+++ b/UI/MainUI/SOGoRootPage.m
@@ -228,7 +228,8 @@
       if ([domain isNotNull])
         {
           sd = [SOGoSystemDefaults sharedSystemDefaults];
-          if ([sd enableDomainBasedUID])
+          if ([sd enableDomainBasedUID] &&
+              [username rangeOfString: @"@"].location == NSNotFound)
             username = [NSString stringWithFormat: @"%@@%@", username, domain];
         }
 
@@ -587,7 +588,8 @@
       if ([domain isNotNull])
         {
           sd = [SOGoSystemDefaults sharedSystemDefaults];
-          if ([sd enableDomainBasedUID])
+          if ([sd enableDomainBasedUID] &&
+              [username rangeOfString: @"@"].location == NSNotFound)
             username = [NSString stringWithFormat: @"%@@%@", username, domain];
         }
       


### PR DESCRIPTION
There are two fixes here, one is mayor and the other is minor. Both only applies for multidomain sogo scenario and are issues related with cached data related with logged users.

* Avoid creating cache entries like `user+attributes` (in case you logged in as, e.g., `user@foo.com`) to avoid reading emails from another user with same name but from different domain (e.g. `user@bar.com`).
* Avoid creating cache entries like `user@domain@domain+attributes`, no need to create that, there was being dup info (same contents that `user@domain+attributes` entries, depending of the method one of those was being read/written).

I'll let as exercise to the reader to determine which one is the mayor and which the minor one.

Suggested change to `NEWS` under `bug fix` section:
`Fixed reading emails from another user with same uid but from a different domain`

How To test this:
* Create two users with same uid but different domains.
* Log in sogo with `user 1`, open another browser and log in as `user 2`.
* Refresh `user 1` mails and also `user 2`'s (surprise mothe... I mean oh! mails from another user).