### PR TITLE
Try to authenticate only against sources of the given domain

### DIFF
--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -425,9 +425,19 @@ static Class NSNullK;
   NSEnumerator *authIDs;
   NSString *currentID;
   BOOL checkOK;
-  
+  SOGoSystemDefaults *sd;
+  NSRange r;
+
   checkOK = NO;
-  
+
+  if (*domain == nil)
+    {
+      sd = [SOGoSystemDefaults sharedSystemDefaults];
+      r = [login rangeOfString: @"@" options: NSBackwardsSearch];
+      if ([sd enableDomainBasedUID] && r.location != NSNotFound)
+        *domain = [login substringFromIndex: (r.location + r.length)];
+    }
+
   authIDs = [[self authenticationSourceIDsInDomain: *domain] objectEnumerator];
   while (!checkOK && (currentID = [authIDs nextObject]))
     {


### PR DESCRIPTION
Right now it tries to authenticate against all ldap sources. So if you have 200 companies with 1 ldap source per company (and the user trying to authenticate belongs the last of that list) it will try to authenticate against 200 ldaps.

With this patch it will try to authenticate only against the sources of that domain (1 in this case)