### PR TITLE
Use UTC offset to encode NSCalendarDate in BSON

### DIFF
--- a/SoObjects/SOGo/BSONCodec.m
+++ b/SoObjects/SOGo/BSONCodec.m
@@ -1,10 +1,12 @@
-//
-//  BSONCodec.m
-//  BSON Codec for Objective-C.
-//
-//  Created by Martin Kou on 8/17/10.
-//  MIT License, see LICENSE file for details.
-//
+/*
+ *  BSONCodec.m
+ *  BSON Codec for Objective-C.
+ *
+ *  Created by Martin Kou on 8/17/10.
+ *  MIT License, see LICENSE file for details.
+ *
+ *  Adapted by Ludovic Marcotte and Enrique J. Hernández
+*/
 
 #import "BSONCodec.h"
 #import <ctype.h>
@@ -570,7 +572,7 @@ static NSDictionary *BSONTypes()
 {
   NSString *v;
   
-  v = [self descriptionWithCalendarFormat: @"%Y-%m-%d %H:%M:%S %Z"
+  v = [self descriptionWithCalendarFormat: @"%Y-%m-%d %H:%M:%S %z"
                                    locale: nil];
   
   return [v BSONEncode];
@@ -599,7 +601,22 @@ static NSDictionary *BSONTypes()
 
   key = [NSString stringWithFormat: @"%s", timezone];
 
-  if (!(tz = [timezoneCache objectForKey: key]))
+  /* We may have the zone using the UTC offset
+     or abbreviation (deprecated) */
+  if (timezone && strlen(timezone) > 0 && (timezone[0] == '+' || timezone[0] == '-'))
+    {
+      NSCalendarDate *tzDate;
+
+      tzDate = [[NSCalendarDate alloc] initWithString: key
+                                       calendarFormat: @"%z"
+                                               locale: nil];
+      [tzDate autorelease];
+      if (tzDate)
+        tz = [tzDate timeZone];
+      else
+        tz = nil;
+    }
+  else if (!(tz = [timezoneCache objectForKey: key]))
     {
       tz = [NSTimeZone timeZoneWithAbbreviation: key];
 


### PR DESCRIPTION
Using name abbreviation in Objective-C is discouraged
as it stated in the following link:

https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Classes/NSTimeZone_Class/index.html#//apple_ref/occ/clm/NSTimeZone/timeZoneWithAbbreviation:

Indeed, the GNUStep library is generating the name
abbreviation using the system tzdata information
but parsing this data using GNUStep resources making
changes like this:

http://mm.icann.org/pipermail/tz-announce/2014-August/000023.html

Not working until GNUStep reaches these tzdata changes.

Using the UTC offset we are losing the position in planet
Earth but it could be considered valid looking at other
bson implementations.

Suggested entry to `NEWS` in *Bug fixes* section:

   * Dates stored in metadata works along TimeZone updates which fixes several situations such as last modified date for a folder to be returned in the right timezone.
