### PR TITLE
sogo-tool: Added create-folder command

### DIFF
--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -22,6 +22,7 @@ $(SOGO_TOOL)_OBJC_FILES += \
 	SOGoToolRemoveDoubles.m \
 	SOGoToolRenameUser.m \
 	SOGoToolRestore.m \
+	SOGoToolCreateFolder.m \
 	SOGoToolUserPreferences.m \
 	SOGoToolManageEAS.m
 TOOL_NAME += $(SOGO_TOOL)

--- a/Tools/SOGoToolCreateFolder.m
+++ b/Tools/SOGoToolCreateFolder.m
@@ -1,0 +1,175 @@
+/* SOGoToolCreateFolder.m - this file is part of SOGo
+ * Implementation of create-folder command for sogo-tool
+ *
+ * Copyright (C) 2015 Javier Amor Garcia
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSException.h>
+
+#import <SOGo/NSArray+Utilities.h>
+#import <SOGo/SOGoObject.h>
+
+#import <GDLContentStore/GCSFolderManager.h>
+#import <GDLContentStore/GCSFolder.h>
+
+#import "SOGoToolRestore.h"
+
+@interface SOGoToolCreateFolder : SOGoToolRestore
+{
+  NSMutableArray *foldersContents;
+  NSString *folderType;
+}
+
+@end
+
+@implementation SOGoToolCreateFolder
+
++ (NSString *) command
+{
+  return @"create-folder";
+}
+
++ (NSString *) description
+{
+  return @"create folders for a user";
+}
+
+- (id) init
+{
+  if ((self = [super init]))
+    {
+      foldersContents = nil;
+      folderType = nil;
+    }
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [foldersContents release];
+  [folderType release];
+  [super dealloc];
+}
+
+- (void) usage
+{
+  fprintf (stderr, "create-folder user type [displayname ...]\n\n"
+           "           user        the user on which the folder(s) will be created\n"
+           "           type        type of directory. Calendar or Contacts\n"
+           "           displayname display name(s) for the created folder(s)\n\n"
+           "Examples:  sogo-tool create-folder user1 Calendar cal1 cal2\n"
+           "           sogo-tool create-folder user1 Contacts agenda\n");
+}
+
+- (BOOL) createNewFolderOfType: (NSString *) type
+                   withContent:  (NSDictionary *) content
+{
+  NSString *folder;
+  NSString *guid;
+  GCSFolderManager *fm;
+  GCSFolder *gcsFolder;
+  BOOL rc;
+
+  guid = [SOGoObject globallyUniqueObjectId];
+  folder= [NSString stringWithFormat: @"/Users/%@/%@/%@",
+                                      userID, type, guid];
+  fm = [GCSFolderManager defaultFolderManager];
+
+  rc = [self createFolder: folder withFM: fm];
+  if (!rc)
+    {
+      NSLog (@"Create directory failed at path %s", folder);
+      return NO;
+    }
+
+  gcsFolder = [fm folderAtPath: folder];
+  if (!gcsFolder)
+    {
+      NSLog (@"folder '%@' could not be created", folder);
+      return NO;
+    }
+
+  rc = [self restoreDisplayName: [content objectForKey: @"displayname"]
+                       ofFolder: gcsFolder
+                         withFM: fm];
+  return rc;
+}
+
+- (BOOL) proceed
+{
+  BOOL rc;
+  NSUInteger count, i;
+  NSDictionary * content;
+
+  rc = YES;
+  count = [foldersContents count];
+  for (i = 0; i < count; i++)
+    {
+      content = [foldersContents objectAtIndex: i];
+      if (![self createNewFolderOfType: folderType withContent: content])
+        {
+          rc = NO;
+        }
+    }
+
+  return rc;
+}
+
+- (BOOL) parseArguments
+{
+  NSString *identifier;
+  NSUInteger count, i;
+  NSDictionary *content;
+
+  count = [arguments count];
+  if (count < 3)
+    {
+      [self usage];
+      return NO;
+    }
+
+  identifier = [arguments objectAtIndex: 0];
+  if (![self fetchUserID: identifier])
+    {
+      fprintf (stderr, "Invalid user:%s\n", [identifier cString]);
+      return NO;
+    }
+
+  folderType = [arguments objectAtIndex: 1];
+  if (!([folderType isEqualToString: @"Contacts"] || [folderType isEqualToString: @"Calendar"]))
+    {
+      fprintf (stderr, "Invalid folder type:%s\n", [folderType cString]);
+      return NO;
+    }
+
+  foldersContents = [[NSMutableArray alloc] init];
+  for (i = 2; i < count; i++)
+    {
+      content =  [NSDictionary dictionaryWithObject: [arguments objectAtIndex: i]
+                                             forKey: @"displayname"];
+      [foldersContents addObject: content];
+    }
+
+  return YES;
+}
+
+@end

--- a/Tools/SOGoToolRestore.h
+++ b/Tools/SOGoToolRestore.h
@@ -1,0 +1,48 @@
+/* SOGoToolRestore.h - this file is part of SOGo
+ * Header to allow subclassing of SOGoToolRestore class
+ *
+ * Copyright (C) 2015 Javier Amor Garcia
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+
+#import "SOGoTool.h"
+
+typedef enum SOGoToolRestoreMode {
+  SOGoToolRestoreFolderMode,
+  SOGoToolRestoreFolderDestructiveMode,
+  SOGoToolRestoreListFoldersMode,
+  SOGoToolRestorePreferencesMode
+} SOGoToolRestoreMode;
+
+@interface SOGoToolRestore : SOGoTool
+{
+  NSString *directory;
+  NSString *userID;
+  NSString *restoreFolder;
+  BOOL destructive; /* destructive mode not handled */
+  SOGoToolRestoreMode restoreMode;
+}
+
+- (BOOL) fetchUserID: (NSString *) identifier;
+- (BOOL) createFolder: (NSString *) folder
+               withFM: (GCSFolderManager *) fm;
+- (BOOL) restoreDisplayName: (NSString *) newDisplayName
+                   ofFolder: (GCSFolder *) gcsFolder
+                     withFM: (GCSFolderManager *) fm;
+
+@end

--- a/Tools/SOGoToolRestore.m
+++ b/Tools/SOGoToolRestore.m
@@ -45,32 +45,14 @@
 #import <NGCards/NGVCard.h>
 #import <NGCards/NGVList.h>
 
-#import "SOGoTool.h"
+#import "SOGoToolRestore.h"
 
 /* TODO:
    - respond to "--help restore"
    - handle database connectivity errors
    - handle the case where the restored folder has been deleted
    - write methods in GDLContentStore to get/update displayname
-     and storing roles */ 
-
-typedef enum SOGoToolRestoreMode {
-  SOGoToolRestoreFolderMode,
-  SOGoToolRestoreFolderDestructiveMode,
-  SOGoToolRestoreListFoldersMode,
-  SOGoToolRestorePreferencesMode
-} SOGoToolRestoreMode;
-
-@interface SOGoToolRestore : SOGoTool
-{
-  NSString *directory;
-  NSString *userID;
-  NSString *restoreFolder;
-  BOOL destructive; /* destructive mode not handled */
-  SOGoToolRestoreMode restoreMode;
-}
-
-@end
+     and storing roles */
 
 @implementation SOGoToolRestore
 

--- a/Tools/SOGoToolRestore.m
+++ b/Tools/SOGoToolRestore.m
@@ -40,6 +40,7 @@
 #import <SOGo/SOGoUserManager.h>
 #import <SOGo/SOGoUserProfile.h>
 #import <SOGo/SOGoUserSettings.h>
+#import <SOGo/SOGoSystemDefaults.h>
 
 #import <NGCards/iCalCalendar.h>
 #import <NGCards/NGVCard.h>
@@ -154,10 +155,22 @@
   BOOL rc;
   SOGoUserManager *lm;
   NSDictionary *infos;
+  SOGoSystemDefaults *sd;
+  NSString *uid = nil;
 
   lm = [SOGoUserManager sharedUserManager];
   infos = [lm contactInfosForUserWithUIDorEmail: identifier];
-  ASSIGN (userID, [infos objectForKey: @"c_uid"]);
+  if (infos)
+    {
+      sd = [SOGoSystemDefaults sharedSystemDefaults];
+      if ([sd enableDomainBasedUID])
+        uid = [NSString stringWithFormat: @"%@@%@",
+                        [infos objectForKey: @"c_uid"],
+                        [infos objectForKey: @"c_domain"]];
+      else
+        uid = [infos objectForKey: @"c_uid"];
+    }
+  ASSIGN (userID, uid);
   if (userID)
     rc = YES;
   else


### PR DESCRIPTION
Changes in logs (thanks to sixstone) :

Apart from the above comments, as this includes user-level changes, I'd suggest to add two lines to NEWS, one for New features:

    Added create-folder subcommand to sogo-tool to create contacts and calendar folders

And one for Bug fixes:

    sogo-tool now works in multidomain environments.

