### PR TITLE
Remove left menus after labels removal

### DIFF
--- a/UI/Templates/MailerUI/UIxMailMainFrame.wox
+++ b/UI/Templates/MailerUI/UIxMailMainFrame.wox
@@ -137,7 +137,6 @@
       <li><!-- separator --></li>
       <li><var:string label:value="Move To"/></li>
       <li><var:string label:value="Copy To"/></li>
-      <li><var:string label:value="Label"/></li>
       <li><var:string label:value="Mark"/></li>
       <li><!-- separator --></li>
       <li><var:string label:value="Save As..."/></li>
@@ -156,7 +155,6 @@
       <li><var:string label:value="Move To"/></li>
       <li><var:string label:value="Copy To"/></li>
       <li><!-- separator --></li>
-      <li><var:string label:value="Label"/></li>
       <li><var:string label:value="Mark"/></li>
       <li><!-- separator --></li>
       <li><var:string label:value="Save As..."/></li>


### PR DESCRIPTION
This was left unremoved in this commit 01c63197  leading to errors like the one described here: https://tracker.zentyal.org/issues/3511