### PR TITLE
Fix sharing imap connections between different clients

### DIFF
--- a/OpenChange/MAPIApplication.h
+++ b/OpenChange/MAPIApplication.h
@@ -33,8 +33,9 @@
 }
 
 - (id) authenticatorInContext: (id) context;
-
+- (MAPIStoreUserContext *) userContext;
 - (void) setUserContext: (MAPIStoreUserContext *) newContext;
+- (void) cleanup;
 
 @end
 

--- a/OpenChange/MAPIApplication.m
+++ b/OpenChange/MAPIApplication.m
@@ -76,6 +76,11 @@ MAPIApplication *MAPIApp = nil;
   return NO;
 }
 
+- (MAPIStoreUserContext *) userContext
+{
+    return userContext;
+}
+
 - (void) setUserContext: (MAPIStoreUserContext *) newContext
 {
   /* user contexts must not be retained here ad their holder (mapistore)
@@ -86,6 +91,11 @@ MAPIApplication *MAPIApp = nil;
 - (id) authenticatorInContext: (id) context
 {
   return [userContext authenticator];
+}
+
+- (void) cleanup
+{
+  [userContext deactivate];
 }
 
 @end

--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -63,19 +63,15 @@
   SOGoAppointmentObject *newEntry;
   NSString *name;
 
-  //[self logWithFormat: @"METHOD '%s' (%d)", __FUNCTION__, __LINE__];
+  [[self userContext] activate];
 
   name = [NSString stringWithFormat: @"%@.ics",
                    [SOGoObject globallyUniqueObjectId]];
   newEntry = [SOGoAppointmentObject objectWithName: name
                                        inContainer: sogoObject];
   [newEntry setIsNew: YES];
-  /* the WOContext is required here for resolving notification pages */
-  [newEntry setContext: [[self userContext] woContext]];
   newMessage = [MAPIStoreCalendarMessage mapiStoreObjectWithSOGoObject: newEntry
                                                            inContainer: self];
-
-  
   return newMessage;
 }
 

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -577,7 +577,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
     }
 }
 
-- (void) save: (TALLOC_CTX *) memCtx 
+- (void) save: (TALLOC_CTX *) memCtx
 {
   // iCalCalendar *vCalendar;
   // NSCalendarDate *now;
@@ -634,7 +634,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
                          withActiveUser: activeUser
 	                       inMemCtx: memCtx];
   [self _updateAttachedEvents];
-  [[self userContext] activateWithUser: activeUser];
+  [[self userContext] activate];
   [sogoObject updateContentWithCalendar: calendar
                             fromRequest: nil];
   [self updateVersions];

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -494,6 +494,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   folder = [sogoObject container];
 
   /* reinstantiate the old sogo object and attach it to self */
+  [[self userContext] activate];
   woContext = [[self userContext] woContext];
   if (isNew)
     {

--- a/OpenChange/MAPIStoreContactsFolder.m
+++ b/OpenChange/MAPIStoreContactsFolder.m
@@ -28,6 +28,7 @@
 #import <Contacts/SOGoContactFolders.h>
 
 #import "MAPIApplication.h"
+#import "MAPIStoreUserContext.h"
 #import "MAPIStoreContactsContext.h"
 #import "MAPIStoreContactsMessage.h"
 #import "MAPIStoreContactsMessageTable.h"
@@ -58,10 +59,12 @@
   SOGoContactGCSEntry *newEntry;
   NSString *name;
 
+  [[self userContext] activate];
+
   name = [NSString stringWithFormat: @"%@.vcf",
                    [SOGoObject globallyUniqueObjectId]];
   newEntry = [SOGoContactGCSEntry objectWithName: name
-				     inContainer: sogoObject];
+                                     inContainer: sogoObject];
   [newEntry setIsNew: YES];
   newMessage = [MAPIStoreContactsMessage mapiStoreObjectWithSOGoObject: newEntry
                                                            inContainer: self];
@@ -100,7 +103,7 @@
     rights |= RightsReadItems;
   if (rights != 0)
     rights |= RoleNone; /* actually "folder visible" */
- 
+
   return rights;
 }
 

--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -114,7 +114,7 @@ static NSMutableDictionary *contextClassMapping;
 
   userContext = [MAPIStoreUserContext userContextWithUsername: userName
                                                andTDBIndexing: indexing];
-  [userContext activateWithUser: [userContext sogoUser]];
+  [userContext activate];
 
   classes = GSObjCAllSubclassesOfClass (self);
   max = [classes count];
@@ -426,7 +426,7 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   NSArray *pathComponents;
   NSUInteger count, max;
 
-  [userContext activateWithUser: activeUser];
+  [userContext activate];
   woContext = [userContext woContext];
 
   [self ensureContextFolder];

--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -33,7 +33,6 @@
 #import <SOGo/SOGoUser.h>
 
 #import "MAPIStoreAttachment.h"
-// #import "MAPIStoreAttachmentTable.h"
 #import "MAPIStoreFallbackContext.h"
 #import "MAPIStoreFolder.h"
 #import "MAPIStoreFolderTable.h"
@@ -89,19 +88,19 @@ static NSMutableDictionary *contextClassMapping;
       currentClass = [classes objectAtIndex: count];
       moduleName = [currentClass MAPIModuleName];
       if (moduleName)
-	{
-	  [contextClassMapping setObject: currentClass
+        {
+          [contextClassMapping setObject: currentClass
                                   forKey: moduleName];
-	  NSLog (@"  registered class '%@' as handler of '%@' contexts",
-		 NSStringFromClass (currentClass), moduleName);
-	}
+          NSLog (@"  registered class '%@' as handler of '%@' contexts",
+                 NSStringFromClass (currentClass), moduleName);
+        }
     }
 
   MAPIStoreFallbackContextK = [MAPIStoreFallbackContext class];
 }
 
 + (struct mapistore_contexts_list *) listAllContextsForUser: (NSString *)  userName
-                                            withIndexing: (struct indexing_context *) indexing
+                                               withIndexing: (struct indexing_context *) indexing
                                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   struct mapistore_contexts_list *list, *current;
@@ -121,7 +120,7 @@ static NSMutableDictionary *contextClassMapping;
     {
       currentClass = [classes objectAtIndex: count];
       current = [currentClass listContextsForUser: userName
-                                  withIndexing: indexing
+                                     withIndexing: indexing
                                          inMemCtx: memCtx];
       if (current)
         DLIST_CONCATENATE(list, current, void);
@@ -131,7 +130,7 @@ static NSMutableDictionary *contextClassMapping;
 }
 
 + (struct mapistore_contexts_list *) listContextsForUser: (NSString *) userName
-                                         withIndexing: (struct indexing_context *) indexing
+                                            withIndexing: (struct indexing_context *) indexing
                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return NULL;
@@ -224,8 +223,6 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   NSURL *baseURL;
   int rc = MAPISTORE_ERR_NOT_FOUND;
 
-  //NSLog (@"METHOD '%s' (%d) -- uri: '%s'", __FUNCTION__, __LINE__, newUri);
-
   context = nil;
 
   baseURL = CompleteURLFromMapistoreURI (newUri);
@@ -297,13 +294,6 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
       ASSIGN (userContext,
               [MAPIStoreUserContext userContextWithUsername: username
                                              andTDBIndexing: indexing]);
-
-#if 0
-      mapistore_mgmt_backend_register_user (newConnInfo,
-                                            "SOGo",
-                                            [username UTF8String]);
-#endif
-
       connInfo = newConnInfo;
       username = [NSString stringWithUTF8String: newConnInfo->username];
       ASSIGN (activeUser, [SOGoUser userWithLogin: username]);
@@ -321,12 +311,6 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
 
 - (void) dealloc
 {
-#if 0
-  mapistore_mgmt_backend_unregister_user ([self connectionInfo], "SOGo", 
-                                          [[userContext username]
-                                            UTF8String]);
-#endif
-
   [contextUrl release];
   [userContext release];
   [containersBag release];
@@ -354,27 +338,16 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   return activeUser;
 }
 
-// - (void) logRestriction: (struct mapi_SRestriction *) res
-// 	      withState: (MAPIRestrictionState) state
-// {
-//   NSString *resStr;
-
-//   resStr = MAPIStringForRestriction (res);
-
-//   [self logWithFormat: @"%@  -->  %@", resStr, MAPIStringForRestrictionState (state)];
-// }
-
 - (int) getPath: (char **) path
          ofFMID: (uint64_t) fmid
        inMemCtx: (TALLOC_CTX *) memCtx
 {
   int rc;
   NSString *objectURL, *url;
-  // TDB_DATA key, dbuf;
 
   url = [contextUrl absoluteString];
   // FIXME transform percent escapes but not for user part of the url
-  //stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+  //[xxxx stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
   objectURL = [[userContext mapping] urlFromID: fmid];
   if (objectURL)
     {
@@ -395,14 +368,6 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   else
     {
       [self errorWithFormat: @"%s: you should *never* get here", __PRETTY_FUNCTION__];
-      // /* attempt to populate our mapping dict with data from indexing.tdb */
-      // key.dptr = (unsigned char *) talloc_asprintf (memCtx, "0x%.16llx",
-      //                                               (long long unsigned int )fmid);
-      // key.dsize = strlen ((const char *) key.dptr);
-
-      // dbuf = tdb_fetch (memCtx->indexing_list->index_ctx->tdb, key);
-      // talloc_free (key.dptr);
-      // uri = talloc_strndup (memCtx, (const char *)dbuf.dptr, dbuf.dsize);
       *path = NULL;
       rc = MAPISTORE_SUCCESS;
     }
@@ -487,7 +452,7 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
 /* utils */
 
 - (NSString *) extractChildNameFromURL: (NSString *) objectURL
-			andFolderURLAt: (NSString **) folderURL;
+                        andFolderURLAt: (NSString **) folderURL;
 {
   NSString *childKey;
   NSRange lastSlash;
@@ -496,15 +461,15 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   if ([objectURL hasSuffix: @"/"])
     objectURL = [objectURL substringToIndex: [objectURL length] - 2];
   lastSlash = [objectURL rangeOfString: @"/"
-			       options: NSBackwardsSearch];
+                               options: NSBackwardsSearch];
   if (lastSlash.location != NSNotFound)
     {
       slashPtr = NSMaxRange (lastSlash);
       childKey = [objectURL substringFromIndex: slashPtr];
       if ([childKey length] == 0)
-	childKey = nil;
+        childKey = nil;
       if (folderURL)
-	*folderURL = [objectURL substringToIndex: slashPtr];
+        *folderURL = [objectURL substringToIndex: slashPtr];
     }
   else
     childKey = nil;
@@ -530,8 +495,6 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   mappingId = [mapping idFromURL: childURL];
   if (mappingId == NSNotFound)
     {
-      //[self warnWithFormat: @"no id exist yet for '%@', requesting one...",
-      //      childURL];
       mapistore_indexing_get_new_folderID (connInfo->mstore_ctx, &mappingId);
       [mapping registerURL: childURL withID: mappingId];
       contextId = 0;
@@ -594,15 +557,14 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
 
   memCtx = talloc_zero(NULL, TALLOC_CTX);
   newFMIDs = [NSMutableArray arrayWithCapacity: max];
-  
+
   if (mapistore_indexing_get_new_folderIDs (connInfo->mstore_ctx,
                                             memCtx, max, &numbers)
       != MAPISTORE_SUCCESS || numbers->cValues != max)
     abort ();
   for (count = 0; count < max; count++)
     {
-      newNumber
-        = [NSString stringWithUnsignedLongLong: numbers->lpui8[count]];
+      newNumber = [NSString stringWithUnsignedLongLong: numbers->lpui8[count]];
       [newFMIDs addObject: newNumber];
     }
 

--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -108,13 +108,12 @@ static NSMutableDictionary *contextClassMapping;
   NSArray *classes;
   Class currentClass;
   NSUInteger count, max;
-  MAPIStoreUserContext *userContext;
 
   list = NULL;
 
-  userContext = [MAPIStoreUserContext userContextWithUsername: userName
-                                               andTDBIndexing: indexing];
-  [userContext activate];
+  // User context is activated on initialization
+  [MAPIStoreUserContext userContextWithUsername: userName
+                                 andTDBIndexing: indexing];
 
   classes = GSObjCAllSubclassesOfClass (self);
   max = [classes count];

--- a/OpenChange/MAPIStoreDBFolder.m
+++ b/OpenChange/MAPIStoreDBFolder.m
@@ -161,7 +161,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
       else
         [dbFolder changePathTo: [NSString stringWithFormat: @"/fallback/%@", pathComponent]
               intoNewContainer: nil];
-      
+
       mapping = [self mapping];
 
       if (targetFolder)
@@ -193,6 +193,8 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
   SOGoMAPIDBMessage *fsObject;
   NSString *newKey;
 
+  [[self userContext] activate];
+
   newKey = [NSString stringWithFormat: @"%@.plist",
                      [SOGoObject globallyUniqueObjectId]];
   fsObject = [SOGoMAPIDBMessage objectWithName: newKey
@@ -214,10 +216,13 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
   ownerUser = [[self userContext] sogoUser];
   if ([[context activeUser] isEqual: ownerUser]
       || [self subscriberCanReadMessages])
-    keys = [(SOGoCacheGCSFolder *) sogoObject childKeysOfType: MAPIMessageCacheObject
-                                             includeDeleted: NO
-                                          matchingQualifier: qualifier
-                                           andSortOrderings: sortOrderings];
+    {
+      [[self userContext] activate];
+      keys = [(SOGoCacheGCSFolder *) sogoObject childKeysOfType: MAPIMessageCacheObject
+                                                 includeDeleted: NO
+                                              matchingQualifier: qualifier
+                                               andSortOrderings: sortOrderings];
+    }
   else
     keys = [NSArray array];
 
@@ -227,6 +232,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
 - (NSArray *) folderKeysMatchingQualifier: (EOQualifier *) qualifier
                          andSortOrderings: (NSArray *) sortOrderings
 {
+  [[self userContext] activate];
   return [dbFolder childKeysOfType: MAPIFolderCacheObject
                     includeDeleted: NO
                  matchingQualifier: qualifier
@@ -262,7 +268,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
       if ([date laterDate: fileDate] == fileDate)
         {
           //[self logWithFormat: @"current date: %@", date];
-          
+
           date = fileDate;
         }
     }
@@ -326,7 +332,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
     rights |= RightsFolderContact;
   if (rights != 0)
     rights |= RoleNone; /* actually "folder visible" */
- 
+
   return rights;
 }
 
@@ -361,7 +367,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
      subscribed to read an open contained messages in order to enable them to
      find the "LocalFreebusy" message */
   [sogoObject reloadIfNeeded];
-  
+
   displayName = [[sogoObject properties]
                   objectForKey: MAPIPropertyKey (PidTagDisplayName)];
 

--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -231,30 +231,19 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
 - (id) lookupFolder: (NSString *) folderKey
 {
-  MAPIStoreFolder *childFolder;
+  MAPIStoreFolder *childFolder = nil;
   SOGoFolder *sogoFolder;
-  WOContext *woContext;
 
-  childFolder = nil;
   if ([[self folderKeys] containsObject: folderKey])
     {
-      woContext = [[self userContext] woContext];
-      /* We activate the user for the context using the root folder
-         context as there are times where the active user is not
-         matching with the one stored in the application context
-         and SOGo object is storing cached data with the wrong user */
-      [[self userContext] activateWithUser: [woContext activeUser]];
-      sogoFolder = [sogoObject lookupName: folderKey inContext: woContext
+      [[self userContext] activate];
+      sogoFolder = [sogoObject lookupName: folderKey
+                                inContext: nil
                                   acquire: NO];
       if (sogoFolder && ![sogoFolder isKindOfClass: NSExceptionK])
-        {
-          [sogoFolder setContext: woContext];
-          childFolder = [isa mapiStoreObjectWithSOGoObject: sogoFolder
-                                               inContainer: self];
-        }
+        childFolder = [isa mapiStoreObjectWithSOGoObject: sogoFolder
+                                             inContainer: self];
     }
-  else
-    childFolder = nil;
 
   return childFolder;
 }

--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -120,6 +120,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
     folderName = [folderURL host];
 
   userContext = [self userContext];
+  [userContext activate];
   [userContext ensureFolderTableExists];
 
   ASSIGN (dbFolder,
@@ -274,6 +275,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
   if (messageKey)
     {
+      [[self userContext] activate];
       msgObject = [sogoObject lookupName: messageKey
                                inContext: nil
                                  acquire: NO];
@@ -303,6 +305,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
   if (messageKey)
     {
+      [[self userContext] activate];
       if ([[self faiMessageKeys] containsObject: messageKey])
         {
           msgObject = [dbFolder lookupName: messageKey
@@ -535,6 +538,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
   context = [self context];
   ownerUser = [[self userContext] sogoUser];
+  [[self userContext] activate];
 
   if ([[context activeUser] isEqual: ownerUser]
       || (!isAssociated && [self subscriberCanCreateMessages]))
@@ -747,9 +751,9 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
     }
   else
     rc = MAPISTORE_ERR_DENIED;
-  
+
   //talloc_free (memCtx);
-  
+
   return rc;
 }
 
@@ -920,7 +924,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   NSArray *newIDs;
   uint64_t idNbr;
   bool softDeleted;
-  
+
   baseURL = [self url];
 
   mapping = [self mapping];
@@ -1094,6 +1098,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 - (NSArray *) faiMessageKeysMatchingQualifier: (EOQualifier *) qualifier
                              andSortOrderings: (NSArray *) sortOrderings
 {
+  [[self userContext] activate];
   return [dbFolder childKeysOfType: MAPIFAICacheObject
                     includeDeleted: NO
                  matchingQualifier: qualifier
@@ -1202,7 +1207,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
 /*
   Possible values are:
-  
+
   0x00000001 Modify
   0x00000002 Read
   0x00000004 Delete
@@ -1233,7 +1238,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
     access |= 0x10;
   if (userIsOwner)
     access |= 0x20;
-  
+
   *data = MAPILongValue (memCtx, access);
 
   return MAPISTORE_SUCCESS;
@@ -1262,7 +1267,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
     rights |= RightsCreateSubfolders;
   if (userIsOwner)
     rights |= RightsFolderOwner | RightsFolderContact;
-  
+
   *data = MAPILongValue (memCtx, rights);
 
   return MAPISTORE_SUCCESS;
@@ -1298,7 +1303,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, [self supportsSubFolders] && [[self folderKeys] count] > 0);
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -1306,7 +1311,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, [[self folderKeys] count]);
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -1408,7 +1413,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   [dbObject setIsNew: YES];
   newMessage = [MAPIStoreFAIMessageK mapiStoreObjectWithSOGoObject: dbObject
                                                        inContainer: self];
-  
+
   return newMessage;
 }
 
@@ -1416,6 +1421,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 {
   MAPIStoreMessage *newMessage;
   WOContext *woContext;
+
+  [[self userContext] activate];
 
   if (isAssociated)
     newMessage = [self _createAssociatedMessage];
@@ -1616,7 +1623,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 
       permissionUser = nil;
       permissionRoles = nil;
- 
+
       if (currentPermission->PermissionDataFlags == ROW_ADD)
         isAdd = YES;
       else if (currentPermission->PermissionDataFlags == ROW_MODIFY)
@@ -1767,7 +1774,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 {
   [self subclassResponsibility: _cmd];
 
-  return nil;  
+  return nil;
 }
 
 - (NSArray *) getDeletedKeysFromChangeNumber: (uint64_t) changeNum

--- a/OpenChange/MAPIStoreGCSBaseContext.m
+++ b/OpenChange/MAPIStoreGCSBaseContext.m
@@ -121,7 +121,6 @@
 
   userContext = [MAPIStoreUserContext userContextWithUsername: userName
                                                andTDBIndexing: NULL];
-  [userContext activate];
   moduleName = [self MAPIModuleName];
   parentFolder = [[userContext rootFolders] objectForKey: moduleName];
   nameInContainer = nil;

--- a/OpenChange/MAPIStoreGCSBaseContext.m
+++ b/OpenChange/MAPIStoreGCSBaseContext.m
@@ -121,7 +121,7 @@
 
   userContext = [MAPIStoreUserContext userContextWithUsername: userName
                                                andTDBIndexing: NULL];
-  [MAPIApp setUserContext: userContext];
+  [userContext activate];
   moduleName = [self MAPIModuleName];
   parentFolder = [[userContext rootFolders] objectForKey: moduleName];
   nameInContainer = nil;
@@ -134,7 +134,6 @@
                              moduleName, nameInContainer];
   else
     mapistoreURI = nil;
-  [MAPIApp setUserContext: nil];
 
   return mapistoreURI;
 }

--- a/OpenChange/MAPIStoreMailContext.m
+++ b/OpenChange/MAPIStoreMailContext.m
@@ -67,7 +67,7 @@ MakeDisplayFolderName (NSString *folderName)
   NSArray *parts;
   NSString *lastFolder;
   NSUInteger max;
- 
+
   parts = [folderName componentsSeparatedByString: @"/"];
   max = [parts count];
   if (max > 1)
@@ -198,7 +198,7 @@ MakeDisplayFolderName (NSString *folderName)
 
   userContext = [MAPIStoreUserContext userContextWithUsername: userName
                                                andTDBIndexing: NULL];
-  [MAPIApp setUserContext: userContext];
+  [userContext activate];
   accountFolder = [[userContext rootFolders] objectForKey: @"mail"];
   folderName = [NSString stringWithFormat: @"folder%@",
                          [newFolderName asCSSIdentifier]];
@@ -213,7 +213,6 @@ MakeDisplayFolderName (NSString *folderName)
                              [[folderName stringByEncodingImap4FolderName] stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]];
   else
     mapistoreURI = nil;
-  [MAPIApp setUserContext: nil];
 
   return mapistoreURI;
 }

--- a/OpenChange/MAPIStoreMailContext.m
+++ b/OpenChange/MAPIStoreMailContext.m
@@ -198,7 +198,6 @@ MakeDisplayFolderName (NSString *folderName)
 
   userContext = [MAPIStoreUserContext userContextWithUsername: userName
                                                andTDBIndexing: NULL];
-  [userContext activate];
   accountFolder = [[userContext rootFolders] objectForKey: @"mail"];
   folderName = [NSString stringWithFormat: @"folder%@",
                          [newFolderName asCSSIdentifier]];

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -139,7 +139,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
       [[self mapping] updateID: fid withURL: [self url]];
       [dbFolder setNameInContainer: newNameInContainer];
       [self cleanupCaches];
-      
+
       propsCopy = [newProperties mutableCopy];
       [propsCopy removeObjectForKey: key];
       [propsCopy autorelease];
@@ -186,10 +186,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
       nameInContainer = [NSString stringWithFormat: @"folder%@",
                                   [[folderName stringByEncodingImap4FolderName] asCSSIdentifier]];
 
-      /* it may be the operation is interleaved with operations
-         from other users having cached information in the thread
-         with the other user, so it'd better activate the user again here... */
-      [[self userContext] activateWithUser: [[[self userContext] woContext] activeUser]];
+      [[self userContext] activate];
 
       newFolder = [SOGoMailFolderK objectWithName: nameInContainer
                                       inContainer: sogoObject];
@@ -245,7 +242,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
                                          sortOrdering: nil]
                 count];
   *data = MAPILongValue (memCtx, longValue);
-  
+
   return MAPISTORE_SUCCESS;
 }
 

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -250,7 +250,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPF.Note" asUnicodeInMemCtx: memCtx];
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -262,7 +262,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   if (!nonDeletedQualifier)
     {
       deletedQualifier
-        = [[EOKeyValueQualifier alloc] 
+        = [[EOKeyValueQualifier alloc]
                  initWithKey: @"FLAGS"
             operatorSelector: EOQualifierOperatorContains
                        value: [NSArray arrayWithObject: @"Deleted"]];
@@ -375,7 +375,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
         [self warnWithFormat: @"qualifier is only used for folders with name"];
       if (sortOrderings)
         [self errorWithFormat: @"sort orderings are not used for folders"];
-      
+
       /* FIXME: Flush any cache before retrieving the hierarchy, this
          slows things down but it is safer */
       if (!qualifier)
@@ -469,7 +469,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
     }
   else
     supportsSubFolders = YES;
-  
+
   return supportsSubFolders;
 }
 
@@ -638,7 +638,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
       fetchResults
         = [fetchResults sortedArrayUsingFunction: _compareFetchResultsByMODSEQ
                                          context: NULL];
-      
+
       for (count = 0; count < max; count++)
         {
           result = [fetchResults objectAtIndex: count];
@@ -948,7 +948,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
         }
     }
   [self _setChangeKey: changeKey forMessageEntry: messageEntry];
-  
+
   [versionsMessage save];
 }
 
@@ -1175,7 +1175,7 @@ _parseIMAPRange (const unichar *uniString, NSArray **UIDsP)
       count++;
     }
   *UIDsP = UIDs;
- 
+
   return count;
 }
 
@@ -1453,7 +1453,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                   [uids addObject: [self messageUIDFromMessageKey: childKey]];
                 }
 
-              result = [client copyUids: uids 
+              result = [client copyUids: uids
                                toFolder: newFolderIMAPName];
               if ([[result objectForKey: @"result"] boolValue])
                 {
@@ -1492,9 +1492,10 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
 {
   SOGoCacheObject *childObject;
 
-  childObject = [SOGoCacheObject objectWithName: [SOGoCacheObject
-                                                  globallyUniqueObjectId]
-                                   inContainer: sogoObject];
+  [[[self context] userContext] activate];
+
+  childObject = [SOGoCacheObject objectWithName: [SOGoCacheObject globallyUniqueObjectId]
+                                    inContainer: sogoObject];
   return [MAPIStoreMailVolatileMessage
            mapiStoreObjectWithSOGoObject: childObject
                              inContainer: self];
@@ -1570,7 +1571,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
     rights |= RoleNone; /* actually "folder visible" */
 
   // [self logWithFormat: @"rights for roles (%@) = %.8x", roles, rights];
- 
+
   return rights;
 }
 
@@ -1621,7 +1622,7 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
                     }
                 }
             }
-      
+
           client = [[(SOGoMailFolder *) sogoObject imap4Connection] client];
           [client select: [sogoObject absoluteImap4Name]];
           response = [client fetchUids: [keyAssoc allKeys]

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1614,6 +1614,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   max = [keyParts count];
   if (max > 0)
     {
+      [[self userContext] activate];
+
       currentPart = [sogoObject lookupName: [keyParts objectAtIndex: 0]
                                  inContext: nil
                                    acquire: NO];

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -1077,6 +1077,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
       dd = [activeUser domainDefaults];
       from = [[activeUser allEmails] objectAtIndex: 0];
 
+      [[self userContext] activate];
       woContext = [[self userContext] woContext];
       authenticator = [sogoObject authenticatorInContext: woContext];
       error = [[SOGoMailer mailerWithDomainDefaults: dd]

--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -61,11 +61,14 @@ static BOOL initialization_done = NO;
     if (!initialization_done) { \
         OC_DEBUG(5, "[SOGo] You should call sogo_backend_init() first. Current thread: %p, pid: %d\n", \
                  GSCurrentThread(), getpid());                         \
-    }
+    } \
+    OC_DEBUG(5, "[SOGo] --->");
+
 #define NS_CURRENT_THREAD_TRY_UNREGISTER() \
     if (__nsrct_thread_registered) { \
         GSUnregisterCurrentThread(); \
-    }
+    } \
+    OC_DEBUG(6, "[SOGo] <---");
 
 #define TRYCATCH_START @try {
 #define TRYCATCH_END(pool)  \
@@ -214,8 +217,6 @@ sogo_backend_create_context(TALLOC_CTX *mem_ctx,
   MAPIStoreContext *context;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
 
@@ -251,8 +252,6 @@ sogo_backend_create_root_folder (const char *username,
   NSString *mapistoreUri;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
 
@@ -287,8 +286,6 @@ sogo_backend_list_contexts(const char *username, struct indexing_context *indexi
   NSAutoreleasePool *pool;
   NSString *userName;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
@@ -336,8 +333,6 @@ sogo_context_get_path(void *backend_object, TALLOC_CTX *mem_ctx,
   MAPIStoreContext *context;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (backend_object)
     {
       wrapper = backend_object;
@@ -369,8 +364,6 @@ sogo_context_get_root_folder(void *backend_object, TALLOC_CTX *mem_ctx,
   MAPIStoreContext *context;
   MAPIStoreFolder *folder;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (backend_object)
     {
@@ -413,8 +406,6 @@ sogo_folder_open_folder(void *folder_object, TALLOC_CTX *mem_ctx, uint64_t fid, 
   MAPIStoreFolder *folder, *childFolder;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -442,7 +433,7 @@ sogo_folder_open_folder(void *folder_object, TALLOC_CTX *mem_ctx, uint64_t fid, 
 
 /**
    \details Create a folder in the sogo backend
-   
+
    \param private_data pointer to the current sogo context
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE_ERROR
@@ -456,8 +447,6 @@ sogo_folder_create_folder(void *folder_object, TALLOC_CTX *mem_ctx,
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder, *childFolder;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -500,8 +489,6 @@ sogo_folder_delete(void *folder_object)
   MAPIStoreFolder *folder;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -531,8 +518,6 @@ sogo_folder_get_child_count(void *folder_object, enum mapistore_table_type table
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -567,8 +552,6 @@ sogo_folder_open_message(void *folder_object,
   MAPIStoreFolder *folder;
   MAPIStoreMessage *message;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -610,8 +593,6 @@ sogo_folder_create_message(void *folder_object,
   MAPIStoreMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -645,8 +626,6 @@ sogo_folder_delete_message(void *folder_object, uint64_t mid, uint8_t flags)
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -683,8 +662,6 @@ sogo_folder_move_copy_messages(void *folder_object,
   NSAutoreleasePool *pool;
   struct MAPIStoreTallocWrapper *wrapper;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -727,8 +704,6 @@ sogo_folder_move_folder(void *folder_object, void *target_folder_object,
   NSString *newFolderName;
   struct MAPIStoreTallocWrapper *wrapper;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -778,8 +753,6 @@ sogo_folder_copy_folder(void *folder_object, void *target_folder_object, TALLOC_
   struct MAPIStoreTallocWrapper *wrapper;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -822,8 +795,6 @@ sogo_folder_get_deleted_fmids(void *folder_object, TALLOC_CTX *mem_ctx,
   MAPIStoreFolder *folder;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -860,8 +831,6 @@ sogo_folder_open_table(void *folder_object, TALLOC_CTX *mem_ctx,
   MAPIStoreFolder *folder;
   MAPIStoreTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -900,8 +869,6 @@ sogo_folder_modify_permissions(void *folder_object, uint8_t flags,
   MAPIStoreFolder *folder;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (folder_object)
     {
       wrapper = folder_object;
@@ -933,8 +900,6 @@ sogo_folder_preload_message_bodies(void *folder_object, enum mapistore_table_typ
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (folder_object)
     {
@@ -969,8 +934,6 @@ sogo_message_get_message_data(void *message_object,
   MAPIStoreMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (message_object)
     {
       wrapper = message_object;
@@ -1003,8 +966,6 @@ sogo_message_create_attachment (void *message_object, TALLOC_CTX *mem_ctx, void 
   MAPIStoreMessage *message;
   MAPIStoreAttachment *attachment;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (message_object)
     {
@@ -1041,8 +1002,6 @@ sogo_message_open_attachment (void *message_object, TALLOC_CTX *mem_ctx,
   MAPIStoreAttachment *attachment;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
   if (message_object)
     {
       wrapper = message_object;
@@ -1076,8 +1035,6 @@ sogo_message_get_attachment_table (void *message_object, TALLOC_CTX *mem_ctx, vo
   MAPIStoreMessage *message;
   MAPIStoreAttachmentTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (message_object)
     {
@@ -1116,9 +1073,6 @@ sogo_message_modify_recipients (void *message_object,
   MAPIStoreMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (message_object)
     {
       wrapper = message_object;
@@ -1152,9 +1106,6 @@ sogo_message_set_read_flag (void *message_object, uint8_t flag)
   MAPIStoreMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (message_object)
     {
       wrapper = message_object;
@@ -1186,9 +1137,6 @@ sogo_message_save (void *message_object, TALLOC_CTX *mem_ctx)
   MAPIStoreMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (message_object)
     {
       wrapper = message_object;
@@ -1219,9 +1167,6 @@ sogo_message_submit (void *message_object, enum SubmitFlags flags)
   NSAutoreleasePool *pool;
   MAPIStoreMailVolatileMessage *message;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (message_object)
     {
@@ -1258,9 +1203,6 @@ sogo_message_attachment_open_embedded_message (void *attachment_object,
   MAPIStoreAttachment *attachment;
   MAPIStoreEmbeddedMessage *message;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (attachment_object)
     {
@@ -1301,9 +1243,6 @@ sogo_message_attachment_create_embedded_message (void *attachment_object,
   MAPIStoreEmbeddedMessage *message;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (attachment_object)
     {
       wrapper = attachment_object;
@@ -1338,9 +1277,6 @@ static enum mapistore_error sogo_table_get_available_properties(void *table_obje
   MAPIStoreTable *table;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (table_object)
     {
       wrapper = table_object;
@@ -1370,9 +1306,6 @@ sogo_table_set_columns (void *table_object, uint16_t count, enum MAPITAGS *prope
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (table_object)
     {
@@ -1404,9 +1337,6 @@ sogo_table_set_restrictions (void *table_object, struct mapi_SRestriction *restr
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (table_object)
     {
@@ -1440,9 +1370,6 @@ sogo_table_set_sort_order (void *table_object, struct SSortOrderSet *sort_order,
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (table_object)
     {
@@ -1479,9 +1406,6 @@ sogo_table_get_row (void *table_object, TALLOC_CTX *mem_ctx,
   MAPIStoreTable *table;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (table_object)
     {
       wrapper = table_object;
@@ -1515,9 +1439,6 @@ sogo_table_get_row_count (void *table_object,
   MAPIStoreTable *table;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (table_object)
     {
       wrapper = table_object;
@@ -1548,9 +1469,6 @@ sogo_table_handle_destructor (void *table_object, uint32_t handle_id)
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (table_object)
     {
@@ -1583,9 +1501,6 @@ static enum mapistore_error sogo_properties_get_available_properties(void *objec
   NSAutoreleasePool *pool;
   MAPIStoreObject *propObject;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (object)
     {
@@ -1620,9 +1535,6 @@ sogo_properties_get_properties (void *object,
   MAPIStoreObject *propObject;
   int rc;
 
-  OC_DEBUG(5, "[SOGo]");
-
-
   if (object)
     {
       wrapper = object;
@@ -1654,9 +1566,6 @@ sogo_properties_set_properties (void *object, struct SRow *aRow)
   NSAutoreleasePool *pool;
   MAPIStoreObject *propObject;
   int rc;
-
-  OC_DEBUG(5, "[SOGo]");
-
 
   if (object)
     {
@@ -1690,8 +1599,6 @@ sogo_manager_generate_uri (TALLOC_CTX *mem_ctx,
 {
   NSAutoreleasePool *pool;
   NSString *partialURLString, *username, *directory;
-
-  OC_DEBUG(5, "[SOGo]");
 
   if (uri == NULL) return MAPISTORE_ERR_INVALID_PARAMETER;
 

--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -603,7 +603,7 @@ sogo_folder_create_message(void *folder_object,
       TRYCATCH_START
       rc = [folder createMessage: &message
                          withMID: mid
-		    isAssociated: associated];
+                    isAssociated: associated];
       if (rc == MAPISTORE_SUCCESS)
         *message_object = [message tallocWrapper: mem_ctx];
       TRYCATCH_END(pool)
@@ -978,7 +978,6 @@ sogo_message_create_attachment (void *message_object, TALLOC_CTX *mem_ctx, void 
       rc = [message createAttachment: &attachment inAID: aidp];
       if (rc == MAPISTORE_SUCCESS)
         *attachment_object = [attachment tallocWrapper: mem_ctx];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1013,7 +1012,6 @@ sogo_message_open_attachment (void *message_object, TALLOC_CTX *mem_ctx,
       rc = [message getAttachment: &attachment withAID: aid];
       if (rc == MAPISTORE_SUCCESS)
         *attachment_object = [attachment tallocWrapper: mem_ctx];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1048,7 +1046,6 @@ sogo_message_get_attachment_table (void *message_object, TALLOC_CTX *mem_ctx, vo
                            andRowCount: row_count];
       if (rc == MAPISTORE_SUCCESS)
         *table_object = [table tallocWrapper: mem_ctx];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1084,7 +1081,6 @@ sogo_message_modify_recipients (void *message_object,
       rc = [message modifyRecipientsWithRecipients: recipients
                                           andCount: count
                                         andColumns: columns];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1115,7 +1111,6 @@ sogo_message_set_read_flag (void *message_object, uint8_t flag)
 
       TRYCATCH_START
       rc = [message setReadFlag: flag];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1146,7 +1141,6 @@ sogo_message_save (void *message_object, TALLOC_CTX *mem_ctx)
 
       TRYCATCH_START
       rc = [message saveMessage: mem_ctx];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1177,7 +1171,6 @@ sogo_message_submit (void *message_object, enum SubmitFlags flags)
 
       TRYCATCH_START
       rc = [message submitWithFlags: flags];
-      // [context tearDownRequest];
       TRYCATCH_END(pool)
 
       [pool release];
@@ -1590,10 +1583,10 @@ sogo_properties_set_properties (void *object, struct SRow *aRow)
 }
 
 static enum mapistore_error
-sogo_manager_generate_uri (TALLOC_CTX *mem_ctx, 
-                           const char *user, 
-                           const char *folder, 
-                           const char *message, 
+sogo_manager_generate_uri (TALLOC_CTX *mem_ctx,
+                           const char *user,
+                           const char *folder,
+                           const char *message,
                            const char *rootURI,
                            char **uri)
 {
@@ -1645,9 +1638,9 @@ sogo_manager_generate_uri (TALLOC_CTX *mem_ctx,
 */
 int mapistore_init_backend(void)
 {
-  struct mapistore_backend	backend;
-  int				ret;
-  static BOOL                   registered = NO;
+  struct mapistore_backend backend;
+  int ret;
+  static BOOL registered = NO;
 
   if (registered)
     ret = MAPISTORE_SUCCESS;

--- a/OpenChange/MAPIStoreTasksFolder.m
+++ b/OpenChange/MAPIStoreTasksFolder.m
@@ -31,6 +31,7 @@
 #import <Appointments/SOGoTaskObject.h>
 
 #import "MAPIApplication.h"
+#import "MAPIStoreUserContext.h"
 #import "MAPIStoreTasksContext.h"
 #import "MAPIStoreTasksMessage.h"
 #import "MAPIStoreTasksMessageTable.h"
@@ -61,6 +62,7 @@
   SOGoTaskObject *newEntry;
   NSString *name;
 
+  [[[self context] userContext] activate];
   name = [NSString stringWithFormat: @"%@.ics",
                    [SOGoObject globallyUniqueObjectId]];
   newEntry = [SOGoTaskObject objectWithName: name
@@ -69,7 +71,7 @@
   newMessage = [MAPIStoreTasksMessage mapiStoreObjectWithSOGoObject: newEntry
                                                         inContainer: self];
 
-  
+
   return newMessage;
 }
 
@@ -116,7 +118,7 @@
     rights |= RightsReadItems;
   if (rights != 0)
     rights |= RoleNone; /* actually "folder visible" */
- 
+
   return rights;
 }
 

--- a/OpenChange/MAPIStoreUserContext.h
+++ b/OpenChange/MAPIStoreUserContext.h
@@ -86,6 +86,8 @@
 
 /* SOGo hacky magic */
 - (void) activateWithUser: (SOGoUser *) activeUser;
+- (void) activate;
+- (void) deactivate;
 - (MAPIStoreAuthenticator *) authenticator;
 - (WOContext *) woContext;
 

--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -159,6 +159,8 @@ static NSMapTable *contextsTable = nil;
       if ([userPassword length] == 0)
         userPassword = username;
       [authenticator setPassword: userPassword];
+      // Activate the profile on initialization
+      [self activate];
     }
 
   return self;

--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -39,6 +39,7 @@
 #import <SOGo/SOGoUser.h>
 #import <SOGo/SOGoUserFolder.h>
 #import <SOGo/NSString+Utilities.h>
+#import <NGExtensions/NSObject+Logs.h>
 #import <Mailer/SOGoMailAccount.h>
 #import <Mailer/SOGoMailAccounts.h>
 
@@ -369,6 +370,11 @@ static NSMapTable *contextsTable = nil;
   return authenticator;
 }
 
+- (void) activate
+{
+  [self activateWithUser: [self sogoUser]];
+}
+
 - (void) activateWithUser: (SOGoUser *) activeUser;
 {
   NSMutableDictionary *info;
@@ -377,6 +383,26 @@ static NSMapTable *contextsTable = nil;
   [woContext setActiveUser: activeUser];
   info = [[NSThread currentThread] threadDictionary];
   [info setObject: woContext forKey: @"WOContext"];
+}
+
+- (void) deactivate
+{
+  NSMutableDictionary *info;
+
+  if (self == [MAPIApp userContext])
+    [MAPIApp setUserContext: nil];
+  else
+    [self errorWithFormat: @"Error: Tried to deactivate an user context "
+                           @"not enabled (%@ vs %@)",
+                           [self username], [[MAPIApp userContext] username]];
+
+  info = [[NSThread currentThread] threadDictionary];
+  if (woContext == [info objectForKey: @"WOContext"])
+    [info removeObjectForKey: @"WOContext"];
+  else
+    [self errorWithFormat: @"Error: Tried to deactivate a WOContext "
+                           @"not enabled (%@ vs %@)",
+                           woContext, [info objectForKey: @"WOContext"]];
 }
 
 @end

--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -217,7 +217,7 @@ static NSMapTable *contextsTable = nil;
   if (!userFolder)
     {
        userFolder = [SOGoUserFolder objectWithName: username
-                                       inContainer: MAPIApp];
+                                       inContainer: nil];
        [userFolder retain];
     }
 
@@ -235,7 +235,8 @@ static NSMapTable *contextsTable = nil;
   if (!rootFolders)
     {
       rootFolders = [NSMutableDictionary new];
-      [self userFolder];
+      [self activate];
+      [self userFolder]; // force lazy initialization
       [woContext setClientObject: userFolder];
 
       /* Calendar */
@@ -260,10 +261,10 @@ static NSMapTable *contextsTable = nil;
                                       acquire: NO];
       [containersBag addObject: accountsFolder];
       [woContext setClientObject: accountsFolder];
+
       currentFolder = [accountsFolder lookupName: @"0"
                                        inContext: woContext
                                          acquire: NO];
-
       [rootFolders setObject: currentFolder
                       forKey: @"mail"];
       connection = [currentFolder imap4Connection];
@@ -271,8 +272,7 @@ static NSMapTable *contextsTable = nil;
 
       /* ensure the folder cache is filled */
       [currentFolder toManyRelationshipKeysWithNamespaces: YES];
-      hierarchy = [connection
-                    cachedHierarchyResultsForURL: [currentFolder imap4URL]];
+      hierarchy = [connection cachedHierarchyResultsForURL: [currentFolder imap4URL]];
       flags = [[hierarchy  objectForKey: @"list"] objectForKey: @"/INBOX"];
       inboxHasNoInferiors = [flags containsObject: @"noinferiors"];
     }
@@ -341,7 +341,7 @@ static NSMapTable *contextsTable = nil;
 
   cm = [GCSChannelManager defaultChannelManager];
   channel = [cm acquireOpenChannelForURL: folderTableURL];
-  
+
   /* FIXME: make use of [EOChannelAdaptor describeTableNames] instead */
   tableName = [[folderTableURL path] lastPathComponent];
   if ([channel evaluateExpressionX:
@@ -358,7 +358,7 @@ static NSMapTable *contextsTable = nil;
     [channel cancelFetch];
 
 
-  [cm releaseChannel: channel]; 
+  [cm releaseChannel: channel];
 }
 
 /* SOGo context objects */


### PR DESCRIPTION
Two main fixes:

1. Disable current user context when an operation has ended.
2. Enable user context before creating sogo objects.


Without this there were situations where you could use an imap connection from another user because some objects were created with a WOContext with an active user different of the current one (but from a previous request).

Suggested messages for NEWS:
* Fixed several sync issues on environments with multiple users
* Folders from other users will no longer appear on your Outlook