### PR TITLE
oc-mail: Added [MAPIStoreFolder getPidTagDisplayName:inMemCtx:]

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -257,16 +257,6 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   return MAPISTORE_SUCCESS;
 }
 
-
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
-{
-  NSString *displayName = [[sogoObject displayName] stringByDecodingImap4FolderName];
-  *data =  [displayName asUnicodeInMemCtx: memCtx];
-
-  return MAPISTORE_SUCCESS;
-}
-
 - (EOQualifier *) nonDeletedQualifier
 {
   static EOQualifier *nonDeletedQualifier = nil;

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -257,6 +257,16 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   return MAPISTORE_SUCCESS;
 }
 
+
+- (int) getPidTagDisplayName: (void **) data
+                    inMemCtx: (TALLOC_CTX *) memCtx
+{
+  NSString *displayName = [[sogoObject displayName] stringByDecodingImap4FolderName];
+  *data =  [displayName asUnicodeInMemCtx: memCtx];
+
+  return MAPISTORE_SUCCESS;
+}
+
 - (EOQualifier *) nonDeletedQualifier
 {
   static EOQualifier *nonDeletedQualifier = nil;

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -1553,7 +1553,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 
 - (NSString *) displayName
 {
-  return [self relativeImap4Name];
+  return [[self relativeImap4Name] stringByDecodingImap4FolderName];
 }
 
 - (NSDictionary *) davIMAPFieldsTable


### PR DESCRIPTION
This getter is necessary to decode folder names
in utf7 encoding.

Suggested message for NEWS:
- Non-latin folder names are displayed correctly on Outlook