### PR TITLE
oc: remove useless mapistore_indexing call

### DIFF
--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -480,11 +480,9 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
 - (uint64_t) idForObjectWithKey: (NSString *) key
                     inFolderURL: (NSString *) folderURL
 {
-  NSString *childURL, *owner;
+  NSString *childURL;
   MAPIStoreMapping *mapping;
   uint64_t mappingId;
-  uint32_t contextId;
-  void *rootObject;
 
   if (key)
     childURL = [NSString stringWithFormat: @"%@%@", folderURL,
@@ -495,15 +493,9 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   mappingId = [mapping idFromURL: childURL];
   if (mappingId == NSNotFound)
     {
+      [self logWithFormat: @"No id exist yet for '%@', requesting one", childURL];
       mapistore_indexing_get_new_folderID (connInfo->mstore_ctx, &mappingId);
       [mapping registerURL: childURL withID: mappingId];
-      contextId = 0;
-
-      mapistore_search_context_by_uri (connInfo->mstore_ctx, [folderURL UTF8String],
-                                       &contextId, &rootObject);
-      owner = [userContext username];
-      mapistore_indexing_record_add_mid (connInfo->mstore_ctx, contextId,
-                                         [owner UTF8String], mappingId);
     }
 
   return mappingId;

--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -483,6 +483,7 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   NSString *childURL;
   MAPIStoreMapping *mapping;
   uint64_t mappingId;
+  enum mapistore_error ret;
 
   if (key)
     childURL = [NSString stringWithFormat: @"%@%@", folderURL,
@@ -494,8 +495,12 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   if (mappingId == NSNotFound)
     {
       [self logWithFormat: @"No id exist yet for '%@', requesting one", childURL];
-      mapistore_indexing_get_new_folderID (connInfo->mstore_ctx, &mappingId);
-      [mapping registerURL: childURL withID: mappingId];
+      ret = mapistore_indexing_get_new_folderID (connInfo->mstore_ctx, &mappingId);
+      if (ret == MAPI_E_SUCCESS)
+        [mapping registerURL: childURL withID: mappingId];
+      else
+        [self errorWithFormat: @"Error trying to get new folder id (%d): %s",
+              ret, mapistore_errstr (ret)];
     }
 
   return mappingId;


### PR DESCRIPTION
[mapping registerURL ...] will insert the mappingId in indexing database
there is no need to call, again, mapistore_indexing_record_add_mid