### PR TITLE
oc-mail: Fallback to PidTagSubject unicode when creating new mail

### DIFF
--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -771,6 +771,12 @@ FillMessageHeadersFromProperties (NGMutableHashMap *headers,
   subjectData = [mailProperties objectForKey: MAPIPropertyKey (PR_NORMALIZED_SUBJECT_UNICODE)];
   if (subjectData)
     [subject appendString: subjectData];
+  if ([subject length] == 0)
+    {
+      subjectData = [mailProperties objectForKey: MAPIPropertyKey (PR_SUBJECT_UNICODE)];
+      if (subjectData)
+        [subject appendString: subjectData];
+    }
   [headers setObject: [subject asQPSubjectString: @"utf-8"] forKey: @"subject"];
 
   messageId = [mailProperties objectForKey: MAPIPropertyKey (PR_INTERNET_MESSAGE_ID_UNICODE)];


### PR DESCRIPTION
Some clients such as OpenChange client does not send the following
properties PidTagNormalizedSubject or PidTagSubjectPrefix as
suggested by [MS-OXCMAIL].

If you think `NEWS` is valuable here, please advise the use of:
* Subject set while sending mails from simple MAPI clients.