### PR TITLE
SOGoUser bad initialization on multidomain environment

### DIFF
--- a/SoObjects/SOGo/SOGoUserManager.m
+++ b/SoObjects/SOGo/SOGoUserManager.m
@@ -394,11 +394,22 @@ static Class NSNullK;
 
 - (NSString *) getUIDForEmail: (NSString *) email
 {
-  NSDictionary *contactInfos;
+  NSDictionary *info;
+  SOGoSystemDefaults *sd;
+  NSString *uid, *domain;
 
-  contactInfos = [self contactInfosForUserWithUIDorEmail: email];
+  info = [self contactInfosForUserWithUIDorEmail: email];
+  uid = [info objectForKey: @"c_uid"];
 
-  return [contactInfos objectForKey: @"c_uid"];
+  sd = [SOGoSystemDefaults sharedSystemDefaults];
+  if ([sd enableDomainBasedUID]
+      && ![[info objectForKey: @"DomainLessLogin"] boolValue])
+    {
+      domain = [info objectForKey: @"c_domain"];
+      uid = [NSString stringWithFormat: @"%@@%@", uid, domain];
+    }
+
+  return uid;
 }
 
 - (BOOL) _sourceChangePasswordForLogin: (NSString *) login


### PR DESCRIPTION
Behaviour noticed in our tests: users couldn't log in through web interface (users use email as login).

The reason was that there was its information cached with `DomainLessLogin` set to true (so the user couldn't authenticate properly because sogo code was trying to authenticate using only `foo` instead of `foo@domain.com`).

The problem was that before doing this login the test performed some appointments operation with Outlook and there was when the information about the user was being cached incorrectly with `DomainLessLogin` due to a bad initialization of `[SOGoUser initWithLogin: @"foo"]`. With domain based uids (aka multidomain environment) you must initialize `SOGoUser` with `uid@domain` (remember uid is unique only inside the domain, no globally), if you initialize the `SOGoUser` without the domain part, that user will be considered as `DomainLessLogin=True`.

More info in commit's message.

I don't know if is worthy to add a message on `NEWS` but I'm sure that some features related with calendar on outlook will work better now.