### PR TITLE
Remove memcached as a compulsory dependency and suggest it only

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,8 @@ Vcs-Git: git://git.debian.org/git/collab-maint/sogo.git
 
 Package: sogo
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, tmpreaper | systemd, sogo-common (= ${source:Version}), adduser, zip, memcached
-Suggests: postgresql | mysql-server
+Depends: ${shlibs:Depends}, ${misc:Depends}, tmpreaper | systemd, sogo-common (= ${source:Version}), adduser, zip
+Suggests: postgresql | mysql-server, memcached
 Description: Scalable groupware server
  SOGo is a groupware server built around OpenGroupware.org (OGo) and
  the SOPE application server with focus on scalability. It has many


### PR DESCRIPTION
This can only be merged when this two pull requests are merged and released:

https://github.com/Zentyal/zentyal/pull/1759
https://github.com/Zentyal/zinc-puppet/pull/129

So we move the responsibility of make sure that memcached is installed to the integrators instead of doing it in this package. 