### PR TITLE
oc-mail: Increase Change Number after modifying seen flag

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1647,13 +1647,27 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
 
 - (int) setReadFlag: (uint8_t) flag
 {
+  BOOL modified = NO;
+  BOOL alreadyRead = NO;
   NSString *imapFlag = @"\\Seen";
+
+  alreadyRead = [[[sogoObject fetchCoreInfos] objectForKey: @"flags"]
+                  containsObject: @"seen"];
 
   /* TODO: notifications should probably be emitted from here */
   if (flag & CLEAR_READ_FLAG)
-    [sogoObject removeFlags: imapFlag];
+    {
+      [sogoObject removeFlags: imapFlag];
+      modified = alreadyRead;
+    }
   else
-    [sogoObject addFlags: imapFlag];
+    {
+      [sogoObject addFlags: imapFlag];
+      modified = !alreadyRead;
+    }
+
+  if (modified)
+    [(MAPIStoreMailFolder *)[self container] synchroniseCache];
 
   return MAPISTORE_SUCCESS;
 }


### PR DESCRIPTION
It is required when you are using `SynchronizeImportReadStateChanges` ROP
to update the `MetaTagCnsetRead` meta property.

See [MS-OXCFXICS] Section 3.2.5.9.4.6

This could lead to sync issues.

Update `NEWS`:

* Less sync issues when setting read flag