### PR TITLE
sogo-openchange: Support attachments with filename extended parameter

### DIFF
--- a/OpenChange/MAPIStoreMailAttachment.m
+++ b/OpenChange/MAPIStoreMailAttachment.m
@@ -117,19 +117,7 @@
 
 - (NSString *) _fileName
 {
-  NSString *fileName;
-  NSDictionary *parameters;
-
-  fileName = [[bodyInfo objectForKey: @"parameterList"]
-               objectForKey: @"name"];
-  if (!fileName)
-    {
-      parameters = [[bodyInfo objectForKey: @"disposition"]
-                     objectForKey: @"parameterList"];
-      fileName = [parameters objectForKey: @"filename"];
-    }
-
-  return fileName;
+  return [bodyInfo filename];
 }
 
 - (int) getPidTagAttachLongFilename: (void **) data

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1569,9 +1569,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   NSDictionary *parameters;
   NSUInteger count, max;
 
-  parameters = [[bodyInfo objectForKey: @"disposition"]
-                 objectForKey: @"parameterList"];
-  if ([[parameters objectForKey: @"filename"] length] > 0)
+  if ([[bodyInfo filename] length] > 0)
     {
       if ([keyPrefix length] == 0)
         keyPrefix = @"0";


### PR DESCRIPTION
The attachments which used a extended parameter for their filename
('filename*=') where silently dropped.
This was because MAPIStore was only looking for no-extended filename
parameter.
The solution is using the 'filename' from the
SOGOExtension of the NSDictionary interface.