### PR TITLE
oc-mail: Return right change key after saving a draft mail

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.h
+++ b/OpenChange/MAPIStoreMailFolder.h
@@ -52,6 +52,8 @@
 - (NSString *) changeNumberForMessageUID: (NSString *) messageUid;
 - (void) setChangeKey: (NSData *) changeKey
     forMessageWithKey: (NSString *) messageKey;
+- (BOOL) updatePredecessorChangeListWith: (NSData *) changeKey
+                       forMessageWithKey: (NSString *) messageKey;
 - (NSData *) changeKeyForMessageWithKey: (NSString *) messageKey;
 - (NSData *) predecessorChangeListForMessageWithKey: (NSString *) messageKey;
 

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -34,6 +34,7 @@
 #import <NGExtensions/NGBase64Coding.h>
 #import <NGExtensions/NGHashMap.h>
 #import <NGExtensions/NSObject+Logs.h>
+#import <NGExtensions/NSObject+Values.h>
 #import <NGExtensions/NSString+Encoding.h>
 #import <NGMime/NGMimeBodyPart.h>
 #import <NGMime/NGMimeMultipartBody.h>
@@ -285,7 +286,7 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
   version = [properties objectForKey: @"version"];
 
   return (version
-          ? exchange_globcnt ([version unsignedLongLongValue])
+          ? [version unsignedLongLongValue]
           : ULLONG_MAX);
 }
 
@@ -1110,7 +1111,8 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
 
 - (void) save: (TALLOC_CTX *) memCtx
 {
-  NSString *folderName, *flag, *newIdString, *messageKey;
+  BOOL updatedMetadata;
+  NSString *folderName, *flag, *newIdString, *messageKey, *changeNumber;
   NSData *changeKey, *messageData;
   NGImap4Connection *connection;
   NGImap4Client *client;
@@ -1146,21 +1148,33 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
       [sogoObject setNameInContainer: messageKey];
       [mapping registerURL: [self url] withID: mid];
 
-      /* synchronise the cache and update the change key with the one provided
-         by the client. Before doing this, lets issue a unselect/select combo 
-         because of timing issues with Dovecot in obtaining the latest modseq.
-         Sometimes, Dovecot doesn't return the newly appended UID if we do
-         a "UID SORT (DATE) UTF-8 (MODSEQ XYZ) (NOT DELETED)" command (where
-         XYZ is the HIGHESTMODSEQ+1) immediately after IMAP APPEND */
+      /* synchronise the cache and update the predecessor change list
+         with the change key provided by the client. Before doing
+         this, lets issue a unselect/select combo because of timing
+         issues with Dovecot in obtaining the latest modseq.
+         Sometimes, Dovecot doesn't return the newly appended UID if
+         we do a "UID SORT (DATE) UTF-8 (MODSEQ XYZ) (NOT DELETED)"
+         command (where XYZ is the HIGHESTMODSEQ+1) immediately after
+         IMAP APPEND */
       [client unselect];
       [client select: folderName];
 
       [(MAPIStoreMailFolder *) container synchroniseCache];
       changeKey = [properties objectForKey: MAPIPropertyKey (PR_CHANGE_KEY)];
       if (changeKey)
-        [(MAPIStoreMailFolder *) container
-                setChangeKey: changeKey
-           forMessageWithKey: messageKey];
+        {
+          updatedMetadata = [(MAPIStoreMailFolder *) container updatePredecessorChangeListWith: changeKey
+                                                                             forMessageWithKey: messageKey];
+          if (!updatedMetadata)
+            [self warnWithFormat: @"Predecessor change list not updated with client data"];
+        }
+
+      /* Update version property (PR_CHANGE_KEY indeed) as it is
+         requested once it is saved */
+      changeNumber = [(MAPIStoreMailFolder *) container changeNumberForMessageUID: newIdString];
+      if (changeNumber)
+        [properties setObject: [NSNumber numberWithUnsignedLongLong: [changeNumber unsignedLongLongValue] >> 16]
+                       forKey: @"version"];
     }
 }
 

--- a/OpenChange/MAPIStoreMessage.m
+++ b/OpenChange/MAPIStoreMessage.m
@@ -549,11 +549,12 @@ rtf2html (NSData *compressedRTF)
         }
   
       [self save: memCtx];
-      /* We make sure that any change-related properties are removes from the
+      /* We make sure that any change-related properties are removed from the
          properties dictionary, to make sure that related methods will be
          invoked the next time they are requested. */
       [properties removeObjectForKey: MAPIPropertyKey (PidTagChangeKey)];
       [properties removeObjectForKey: MAPIPropertyKey (PidTagChangeNumber)];
+      [properties removeObjectForKey: MAPIPropertyKey (PidTagPredecessorChangeList)];
 
       if ([container isKindOfClass: MAPIStoreFolderK])
         {


### PR DESCRIPTION
After saving a draft mail (this is done automatically by Outlook)
a GetProps call is done checking the PidTagChangeKey has been
updated properly. Without this patch, it returned MAPI_E_NOT_FOUND.

With this patch, we addressed that problem and we have updated
the Predecessor Change List metadata for the draft mail with the
change key provided by the client to avoid conflicting messages
whenever it is possible.

NEWS line:

* Avoid conflicting message on saving a draft mail.

Example NDR output request:

```
                        mapi_request: struct EcDoRpc_MAPI_REQ
                            opnum                    : 0x0c (12)
                            logon_id                 : 0x00 (0)
                            handle_idx               : 0x00 (0)
                            u                        : union EcDoRpc_MAPI_REQ_UNION(case 12)
                            mapi_SaveChangesMessage: struct SaveChangesMessage_req
                                handle_idx               : 0x00 (0)
                                SaveFlags                : 0x08 (8)
                        mapi_request: struct EcDoRpc_MAPI_REQ
                            opnum                    : 0x07 (7)
                            logon_id                 : 0x00 (0)
                            handle_idx               : 0x00 (0)
                            u                        : union EcDoRpc_MAPI_REQ_UNION(case 7)
                            mapi_GetProps: struct GetProps_req
                                PropertySizeLimit        : 0x0000 (0)
                                WantUnicode              : 0x0000 (0)
                                prop_count               : 0x0001 (1)
                                properties: ARRAY(1)
                                    properties               : PidTagChangeKey (0x65E20102)
```