### PR TITLE
oc: load versionsMessage on setting up

### DIFF
--- a/OpenChange/MAPIStoreGCSFolder.m
+++ b/OpenChange/MAPIStoreGCSFolder.m
@@ -75,6 +75,7 @@ static Class NSNumberK;
           [SOGoMAPIDBMessage objectWithName: @"versions.plist"
                                 inContainer: dbFolder]);
   [versionsMessage setObjectType: MAPIInternalCacheObject];
+  [versionsMessage reloadIfNeeded];
 }
 
 - (void) dealloc

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -111,6 +111,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
           [SOGoMAPIDBMessage objectWithName: @"versions.plist"
                                 inContainer: dbFolder]);
   [versionsMessage setObjectType: MAPIInternalCacheObject];
+  [versionsMessage reloadIfNeeded];
 }
 
 - (BOOL) ensureFolderExists


### PR DESCRIPTION
versionsMessage object could have outdated version in a root folder
in the following case:

* Download latest contents using FXBuffer
  * versionsMessage is updated by synchroniseCache
* OpenMessage a new message after synching
  * Setup versions message as root folder
* Get Predecessor Change List of that message

We could just reload if needed the versions message if something
is missing but I don't know if that situation fixes more than this
one.

The performance improvement comes from avoiding, at least, two IMAP calls when they are not required in this situation. A common one if you are receiving mails via notifications.