### PR TITLE
Implement setReadFlag for MAPIStoreDBMessage

### DIFF
--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -671,7 +671,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return newAttachment;
 }
 
-- (int) setReadFlag: (uint8_t) flag
+- (enum mapistore_error) setReadFlag: (uint8_t) flag
 {
   return MAPISTORE_SUCCESS;
 }

--- a/OpenChange/MAPIStoreDBMessage.m
+++ b/OpenChange/MAPIStoreDBMessage.m
@@ -313,4 +313,36 @@
   return [sogoObject lastModified];
 }
 
+- (enum mapistore_error) setReadFlag: (uint8_t) flag
+{
+  /* Modify PidTagMessageFlags from SetMessageReadFlag and
+     SyncImportReadStateChanges ROPs */
+  NSNumber *flags;
+  uint32_t newFlag;
+
+  flags = [properties objectForKey: MAPIPropertyKey (PR_MESSAGE_FLAGS)];
+  if (flags)
+    {
+      newFlag = [flags unsignedLongValue];
+      if (flag & SUPPRESS_RECEIPT)
+        newFlag |= MSGFLAG_READ;
+      if (flag & CLEAR_RN_PENDING)
+        newFlag &= ~MSGFLAG_RN_PENDING;
+      if (flag & CLEAR_READ_FLAG)
+        newFlag &= ~MSGFLAG_READ;
+      if (flag & CLEAR_NRN_PENDING)
+        newFlag &= ~MSGFLAG_NRN_PENDING;
+    }
+  else
+    {
+      newFlag = MSGFLAG_READ;
+      if (flag & CLEAR_READ_FLAG)
+        newFlag = 0x0;
+    }
+  [properties setObject: [NSNumber numberWithUnsignedLong: newFlag]
+                 forKey: MAPIPropertyKey (PR_MESSAGE_FLAGS)];
+
+  return MAPISTORE_SUCCESS;
+}
+
 @end

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1643,7 +1643,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return attachment;
 }
 
-- (int) setReadFlag: (uint8_t) flag
+- (enum mapistore_error) setReadFlag: (uint8_t) flag
 {
   NSString *imapFlag = @"\\Seen";
 

--- a/OpenChange/MAPIStoreMessage.h
+++ b/OpenChange/MAPIStoreMessage.h
@@ -63,7 +63,7 @@
               withAID: (uint32_t) aid;
 - (int) getAttachmentTable: (MAPIStoreAttachmentTable **) tablePtr
                andRowCount: (uint32_t *) countPtr;
-- (int) setReadFlag: (uint8_t) flag;
+- (enum mapistore_error) setReadFlag: (uint8_t) flag;
 - (enum mapistore_error) saveMessage: (TALLOC_CTX *) memCtx;
 
 - (NSArray *) activeContainerMessageTables;

--- a/OpenChange/MAPIStoreMessage.m
+++ b/OpenChange/MAPIStoreMessage.m
@@ -919,7 +919,7 @@ rtf2html (NSData *compressedRTF)
   return [self getNo: data inMemCtx: memCtx];;
 }
 
-- (int) setReadFlag: (uint8_t) flag
+- (enum mapistore_error) setReadFlag: (uint8_t) flag
 {
   // [self subclassResponsibility: _cmd];
 

--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -1120,7 +1120,7 @@ sogo_message_set_read_flag (void *message_object, uint8_t flag)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {


### PR DESCRIPTION
This is an utility for testing as I don't see any added value
for real scenario but according to [MS-OXCMSG] all messages
can have PidTagMessageFlags.

Returned `enum mapistore_error` for `setReadFlag:flag` message has been done as well.