### PR TITLE
Changed logrotate

### DIFF
--- a/debian/sogo.logrotate
+++ b/debian/sogo.logrotate
@@ -5,9 +5,5 @@
 	compress
 	delaycompress
 	notifempty
-	create 640 sogo sogo
-	sharedscripts
-	postrotate
-		/etc/init.d/sogo restart > /dev/null 2>&1
-	endscript
+	copytruncate
 }


### PR DESCRIPTION
We need this as sometimes postrotate script (/etc/init.d/sogo restart) is not able to successfully shut down sogo before restarting it. This has been tested in 1-2 customers and seems to fix the issue