### PR TITLE
Make folderKey encoding consistent 

### DIFF
--- a/OpenChange/MAPIStoreMailContext.m
+++ b/OpenChange/MAPIStoreMailContext.m
@@ -160,23 +160,25 @@ MakeDisplayFolderName (NSString *folderName)
   for (count = 0; count < max; count++)
     {
       context = talloc_zero (memCtx, struct mapistore_contexts_list);
-      // secondaryFolders has the names (1) Imap4Encoded and (2) asCSSIdentifier
-      //     e.g.: Probl&AOg-mes_SP_de_SP_synchronisation
+      // secondaryFolders has the names (1) Imap4Encoded ,(2) asCSSIdentifier and (3) "folder"-prefixed
+      //     e.g.: folderProbl&AOg-mes_SP_de_SP_synchronisation
       currentName = [secondaryFolders objectAtIndex: count];
-      // To get the real name we have to revert that (applying the decode functions)
-      // in reverse order
+      // To get the real name we have to revert that (applying the decode functions
+      // in reverse order)
       //     e.g.: Problèmes de synchronisation
-      realName = [[currentName fromCSSIdentifier]
-                               stringByDecodingImap4FolderName];
+      realName = [[[currentName substringFromIndex: 6]
+                                fromCSSIdentifier]
+                                stringByDecodingImap4FolderName];
       // And finally to represent that as URI we have to (1) asCSSIdentifier,
-      // (2) Imap4Encode and (3) AddPercentEscapes
-      //     e.g.: Probl&AOg-mes_SP_de_SP_synchronisation
+      // (2) Imap4Encode (3) AddPercentEscapes and (4) add the "folder" prefix
+      //     e.g.: folderProbl&AOg-mes_SP_de_SP_synchronisation
       // In the example there are no percent escapes added because is already ok
       stringData = [[[realName asCSSIdentifier]
                                stringByEncodingImap4FolderName]
                                stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+      stringData = [NSString stringWithFormat: @"folder%@", stringData];
       context->url = [[NSString stringWithFormat: @"%@%@", urlBase, stringData] asUnicodeInMemCtx: context];
-      context->name = [[realName substringFromIndex: 6] asUnicodeInMemCtx: context];
+      context->name = [realName asUnicodeInMemCtx: context];
       context->main_folder = false;
       context->role = MAPISTORE_MAIL_ROLE;
       context->tag = "tag";
@@ -200,7 +202,7 @@ MakeDisplayFolderName (NSString *folderName)
                                                andTDBIndexing: NULL];
   accountFolder = [[userContext rootFolders] objectForKey: @"mail"];
   folderName = [NSString stringWithFormat: @"folder%@",
-                         [newFolderName asCSSIdentifier]];
+                         [[newFolderName stringByEncodingImap4FolderName] asCSSIdentifier]];
   newFolder = [SOGoMailFolder objectWithName: folderName
                                  inContainer: accountFolder];
   if ([newFolder create])
@@ -209,7 +211,7 @@ MakeDisplayFolderName (NSString *folderName)
                                        withString: @"%40"],
                              [userName stringByReplacingOccurrencesOfString: @"@"
                                        withString: @"%40"],
-                             [[folderName stringByEncodingImap4FolderName] stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]];
+                             [folderName stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]];
   else
     mapistoreURI = nil;
 

--- a/Scripts/openchange_user_cleanup
+++ b/Scripts/openchange_user_cleanup
@@ -268,6 +268,9 @@ def asCSSIdentifier(inputString):
 
     newChars = []
 
+    if str.isdigit(inputString[0]):
+        newChars.append("_")
+
     for c in inputString:
         if c in cssEscapingCharMap:
             newChars.append(cssEscapingCharMap[c])

--- a/SoObjects/Mailer/SOGoMailAccount.m
+++ b/SoObjects/Mailer/SOGoMailAccount.m
@@ -206,8 +206,8 @@ static NSString *inboxFolderName = @"INBOX";
         [folders removeObjectsInArray: nss];
     }
 
-  return [[folders stringsWithFormat: @"folder%@"]
-           resultsOfSelector: @selector (asCSSIdentifier)];
+  return [[folders resultsOfSelector: @selector (asCSSIdentifier)]
+           stringsWithFormat: @"folder%@"];
 }
 
 - (NSArray *) toManyRelationshipKeys

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -197,9 +197,9 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 {
   NSArray *subfolders;
 
-  subfolders = [[self subfolders] stringsWithFormat: @"folder%@"];
+  subfolders = [[self subfolders] resultsOfSelector: @selector (asCSSIdentifier)];
 
-  return [subfolders resultsOfSelector: @selector (asCSSIdentifier)];
+  return [subfolders stringsWithFormat: @"folder%@"];
 }
 
 - (NSArray *) subfolders
@@ -632,7 +632,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 		inContext: (id) localContext
 {
   NSArray *folders;
-  NSString *currentFolderName, *currentAccountName;
+  NSString *currentFolderName, *currentAccountName, *destinationAccountName;
   NSMutableString *imapDestinationFolder;
   NGImap4Client *client;
   id result;
@@ -640,24 +640,24 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 
 #warning this code will fail on implementation using something else than '/' as delimiter
   imapDestinationFolder = [NSMutableString string];
-  folders = [[destinationFolder componentsSeparatedByString: @"/"]
-              resultsOfSelector: @selector (fromCSSIdentifier)];
+  folders = [destinationFolder componentsSeparatedByString: @"/"];
   max = [folders count];
   if (max > 1)
     {
       currentAccountName = [[self mailAccountFolder] nameInContainer];
       client = [[self imap4Connection] client];
       [imap4 selectFolder: [self imap4URL]];
+      destinationAccountName = [[folders objectAtIndex: 1] fromCSSIdentifier];
 
       for (count = 2; count < max; count++)
         {
-          currentFolderName = [[folders objectAtIndex: count] substringFromIndex: 6];
+          currentFolderName = [[[folders objectAtIndex: count] substringFromIndex: 6] fromCSSIdentifier];
           [imapDestinationFolder appendFormat: @"/%@", currentFolderName];
         }
 
       if (client)
         {
-          if ([[folders objectAtIndex: 1] isEqualToString: currentAccountName])
+          if ([destinationAccountName isEqualToString: currentAccountName])
             {
               // We make sure the destination IMAP folder exist, if not, we create it.
               result = [[client status: imapDestinationFolder
@@ -686,7 +686,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
               
               userFolder = [[context activeUser] homeFolderInContext: context];
               accounts = [userFolder lookupName: @"Mail"  inContext: context  acquire: NO];
-              account = [accounts lookupName: [folders objectAtIndex: 1] inContext: localContext acquire: NO];
+              account = [accounts lookupName: destinationAccountName inContext: localContext acquire: NO];
 
               if ([account isKindOfClass: [NSException class]])
                 {

--- a/UI/MailerUI/UIxMailFolderActions.m
+++ b/UI/MailerUI/UIxMailFolderActions.m
@@ -106,7 +106,7 @@
   keyForMsgUIDs = [NSString stringWithFormat:@"/%@/%@", currentAccount, currentMailbox];
 
   newFolderName = [[context request] formValueForKey: @"name"];
-  newKeyForMsgUIDs = [[NSString stringWithFormat:@"/%@/folder%@", currentAccount, newFolderName] asCSSIdentifier];
+  newKeyForMsgUIDs = [NSString stringWithFormat:@"/%@/folder%@", [currentAccount asCSSIdentifier], [newFolderName asCSSIdentifier]];
   error = [co renameTo: newFolderName];
   if (error)
     {

--- a/UI/MailerUI/UIxMailMainFrame.m
+++ b/UI/MailerUI/UIxMailMainFrame.m
@@ -688,8 +688,8 @@
 
 		  for (k = 0; k < [pathComponents count]; k++)
 		    {
-                      component = [NSString stringWithFormat: @"folder%@", [pathComponents objectAtIndex: k]];
-                      [path appendString: [component asCSSIdentifier]];
+                      component = [[pathComponents objectAtIndex: k] asCSSIdentifier];
+                      [path appendString: [NSString stringWithFormat: @"folder%@", component]];
 		      if (k < [pathComponents count] - 1)
 			[path appendString: @"/"];
 		    }

--- a/UI/WebServerResources/MailerUI.js
+++ b/UI/WebServerResources/MailerUI.js
@@ -3029,7 +3029,7 @@ Mailbox.prototype = {
 
         var currentFolder = this;
         while (currentFolder.parentFolder) {
-            fullName = ("/folder" + currentFolder.name).asCSSIdentifier() + fullName;
+            fullName = "/folder" + currentFolder.name.asCSSIdentifier() + fullName;
             currentFolder = currentFolder.parentFolder;
         }
 


### PR DESCRIPTION
The folder names are encoded through the `asCSSIdentifier` and
`stringByEncodingImap4FolderName` functions when we store them as folder
keys. In addition, the prefix "folder" is added to the key.

The order in which these operations were done when storing the folder
keys (and reverted when retrieving them) wasn't consistent trough the
code. This led to problems such as creating twice a folder with a digit
at the beginning of its name.

The folder name goes now through the following operations when being
stored as a key (the retrieval reverts these in the reverse order):

 * `stringByEncodingImap4FolderName`
 * `asCSSIdentifier`
 * Add "folder" prefix

Suggested `NEWS` line:
 * Fix double creation of folders in OL when the folder name starts with a digit