### PR TITLE
Fix freebusy for multidomain environments

### DIFF
--- a/SoObjects/Contacts/SOGoContactSourceFolder.m
+++ b/SoObjects/Contacts/SOGoContactSourceFolder.m
@@ -48,6 +48,7 @@
 #import <SOGo/SOGoPermissions.h>
 #import <SOGo/SOGoSource.h>
 #import <SOGo/SOGoUserSettings.h>
+#import <SOGo/SOGoSystemDefaults.h>
 #import <SOGo/WORequest+SOGo.h>
 #import <SOGo/WOResponse+SOGo.h>
 
@@ -235,6 +236,13 @@
   if (!data)
     data = @"";
   [newRecord setObject: data forKey: @"c_cn"];
+
+  if ([[SOGoSystemDefaults sharedSystemDefaults] enableDomainBasedUID])
+    {
+      data = [oldRecord objectForKey: @"c_domain"];
+      if (data)
+        [newRecord setObject: data forKey: @"c_domain"];
+    }
 
   data = [oldRecord objectForKey: @"mail"];
   if (!data)

--- a/UI/WebServerResources/UIxAttendeesEditor.js
+++ b/UI/WebServerResources/UIxAttendeesEditor.js
@@ -221,9 +221,11 @@ function performSearchCallback(http) {
                     node.address = completeEmail;
                     // log("node.address: " + node.address);
                     if (contact["c_uid"]) {
-                        node.uid = (contact["isMSExchange"]? UserLogin + ":" : "") + contact["c_uid"];
-                    }
-                    else {
+                        var login = contact["c_uid"];
+                        if (contact["c_domain"])
+                            login += "@" + contact["c_domain"];
+                        node.uid = (contact["isMSExchange"]? UserLogin + ":" : "") + login;
+                    } else
                         node.uid = null;
                         node.appendChild(new Element('div').addClassName('colorBox').addClassName('noFreeBusy'));
                     }
@@ -275,13 +277,16 @@ function performSearchCallback(http) {
             else {
                 if (document.currentPopupMenu)
                     hideMenu(document.currentPopupMenu);
-                
+
                 if (data.contacts.length == 1) {
                     // Single result
                     var contact = data.contacts[0];
-                    if (contact["c_uid"])
-                        input.uid = (contact["isMSExchange"]? UserLogin + ":" : "") + contact["c_uid"];
-                    else
+                    if (contact["c_uid"]) {
+                        var login = contact["c_uid"];
+                        if (contact["c_domain"])
+                            login += "@" + contact["c_domain"];
+                        input.uid = (contact["isMSExchange"]? UserLogin + ":" : "") + login;
+                    } else
                         input.uid = null;
                     var isList = (contact["c_component"] &&
                                   contact["c_component"] == "vlist");


### PR DESCRIPTION
When returning contacts we have to supply also the domain field.
Because in a multidomain environment UIDField is unique only in
the domain so an user must be identified as uid@domain.

So when creating http requests from client side, we have to use
uid@domain instead of only uid so the SOGoUser created on server
side when parsing the requests is created properly.


Message for `NEWS`

    Freebusy on web interface works again in multidomain environments