### PR TITLE
Store c_content in sogo_cache_folder as a BLOB

### DIFF
--- a/SoObjects/SOGo/GCSSpecialQueries+SOGoCacheObject.m
+++ b/SoObjects/SOGo/GCSSpecialQueries+SOGoCacheObject.m
@@ -57,7 +57,7 @@
        @" c_lastmodified INT4 NOT NULL,"
        @" c_version INT4 NOT NULL DEFAULT 0,"
        @" c_deleted SMALLINT NOT NULL DEFAULT 0,"
-       @" c_content TEXT)");
+       @" c_content BYTEA)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }
@@ -77,7 +77,7 @@
        @" c_lastmodified INT NOT NULL,"
        @" c_version INT NOT NULL DEFAULT 0,"
        @" c_deleted TINYINT NOT NULL DEFAULT 0,"
-       @" c_content LONGTEXT)");
+       @" c_content BLOB)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }
@@ -97,7 +97,7 @@
        @" c_lastmodified INT4 NOT NULL,"
        @" c_version INT4 NOT NULL DEFAULT 0,"
        @" c_deleted SMALLINT NOT NULL DEFAULT 0,"
-       @" c_content CLOB)");
+       @" c_content BLOB)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }

--- a/SoObjects/SOGo/SOGoCacheGCSObject.m
+++ b/SoObjects/SOGo/SOGoCacheGCSObject.m
@@ -152,7 +152,7 @@ static EOAttribute *textColumn = nil;
 - (void) setupFromRecord: (NSDictionary *) record
 {
   NSInteger intValue;
-  NSString *propsValue;
+  NSData *content;
   NSDictionary *newValues;
 
   objectType = [[record objectForKey: @"c_type"] intValue];
@@ -166,10 +166,10 @@ static EOAttribute *textColumn = nil;
                dateWithTimeIntervalSince1970: (NSTimeInterval) intValue]);
   deleted = ([[record objectForKey: @"c_deleted"] intValue] > 0);
   version = [[record objectForKey: @"c_version"] intValue];
-  propsValue = [record objectForKey: @"c_content"];
-  if ([propsValue isNotNull])
+  content = [record objectForKey: @"c_content"];
+  if ([content isNotNull])
     {
-      newValues = [[propsValue dataByDecodingBase64] BSONValue];
+      newValues = [[content dataByDecodingBase64] BSONValue];
       [properties addEntriesFromDictionary: newValues];
     }
   else


### PR DESCRIPTION
This reduces considerably the query time for that column, which can be
rather large.

There is a separate PR for the trusty branch, https://github.com/zentyal/sogo/pull/192, that performs the DB migration for this change.