### PR TITLE
Include c_content as a BLOB in the migration

### DIFF
--- a/debian/sogo-openchange.postinst
+++ b/debian/sogo-openchange.postinst
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+case "$1" in
+    configure)
+        restart samba-ad-dc
+        ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+        ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 0
+        ;;
+
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/debian/sogo.postinst
+++ b/debian/sogo.postinst
@@ -90,7 +90,7 @@ case "$1" in
     *)
         echo "postinst called with unknown argument \`$1'" >&2
         exit 0
-    ;;
+	;;
 esac
 
 #DEBHELPER#

--- a/debian/sogo.postinst
+++ b/debian/sogo.postinst
@@ -44,6 +44,20 @@ function runDBMigration() {
     echo "$sqlscript" | mysql -s -u$username -p$password -h $hostname $database || true
 }
 
+function runCacheFolderDBMigration() {
+    username=$(sogo-tool dump-defaults -f /etc/sogo/sogo.conf | awk -F\" '/ OCSFolderInfoURL =/  {print $2}'|cut -d: -f2|cut -d/ -f3)
+    password=$(sogo-tool dump-defaults -f /etc/sogo/sogo.conf | awk -F\" '/ OCSFolderInfoURL =/  {print $2}'|cut -d: -f3|cut -d@ -f1)
+    hostname=$(sogo-tool dump-defaults -f /etc/sogo/sogo.conf | awk -F\" '/ OCSFolderInfoURL =/  {print $2}'|cut -d@ -f2|cut -d: -f1)
+    database=$(sogo-tool dump-defaults -f /etc/sogo/sogo.conf | awk -F\" '/ OCSFolderInfoURL =/  {print $2}'|cut -d/ -f4)
+
+    tables=`mysql -s -u$username -p$password -h $hostname $database -e "show tables like '%cache%';" || true`
+
+    for table in $tables;
+    do
+	echo "alter table $table modify c_content BLOB" | mysql -s -u$username -p$password -h $hostname $database
+    done
+}
+
 case "$1" in
     configure)
 	if ! getent passwd sogo > /dev/null ; then
@@ -61,6 +75,11 @@ case "$1" in
         if [ -n "$2" ] && dpkg --compare-versions "$2" lt "2.3-zentyal1"
         then
             runDBMigration
+        fi
+
+        if [ -n "$2" ] && dpkg --compare-versions "$2" le "2.3.1-zentyal5"
+        then
+            runCacheFolderDBMigration
         fi
 
         ;;


### PR DESCRIPTION
This is a migration for the changes in https://github.com/zentyal/sogo/pull/191, which change the type of the `c_content` column in the `sogo_cache_folder_foo` table from LONGTEXT to BLOB.