### PR TITLE
Ignore recurrence-id vevents without dtstart and outside date range

### DIFF
--- a/SoObjects/Appointments/SOGoAppointmentFolder.m
+++ b/SoObjects/Appointments/SOGoAppointmentFolder.m
@@ -1063,7 +1063,7 @@ firstInstanceCalendarDateRange: (NGCalendarDateRange *) fir
 	{
           if ([dateRange containsDate: [component startDate]])
             {
-              // We must pass nill to :container here in order to avoid re-entrancy issues.
+              // We must pass nil to :container here in order to avoid re-entrancy issues.
               newRecord = [self _fixupRecord: [component quickRecordFromContent: nil  container: nil]];
               [ma replaceObjectAtIndex: recordIndex withObject: newRecord];
             }
@@ -1080,15 +1080,20 @@ firstInstanceCalendarDateRange: (NGCalendarDateRange *) fir
     {
       // The recurrence id of the exception is outside the date range;
       // simply add the exception to the records array.
-      // We must pass nill to :container here in order to avoid re-entrancy issues.
+      // We must pass nil to :container here in order to avoid re-entrancy issues.
       newRecord = [self _fixupRecord: [component quickRecordFromContent: nil  container: nil]];
-      newRecordRange = [NGCalendarDateRange 
-			 calendarDateRangeWithStartDate: [newRecord objectForKey: @"startDate"]
-			 endDate: [newRecord objectForKey: @"endDate"]];
-      if ([dateRange doesIntersectWithDateRange: newRecordRange])
+      if ([newRecord objectForKey: @"startDate"] && [newRecord objectForKey: @"endDate"]) {
+        newRecordRange = [NGCalendarDateRange
+                           calendarDateRangeWithStartDate: [newRecord objectForKey: @"startDate"]
+                                                  endDate: [newRecord objectForKey: @"endDate"]];
+        if ([dateRange doesIntersectWithDateRange: newRecordRange])
           [ma addObject: newRecord];
-      else
+        else
+          newRecord = nil;
+      } else {
+        [self warnWithFormat: @"Recurrence %@ without dtstart or dtend. Ignoring", recurrenceId];
         newRecord = nil;
+      }
     }
 
   if (newRecord)


### PR DESCRIPTION
Happened in an imported vevent from Mozilla Thunderbird.

The crash was:

```
  Sep 14 15:49:38 sogod [21063]: <0x6442DBF8[SOGoAppointmentFolder]:personal> missing 'c_startdate' in record?
  Sep 14 15:49:38 sogod [21063]: <0x6442DBF8[SOGoAppointmentFolder]:personal> missing 'c_enddate' in record?
  2015-09-14 15:49:38.927 sogod[21063] NGCalendarDateRange.m:37  Assertion failed in NGCalendarDateRange(instance), method initWithStartDate:endDate:.  startDate MUST NOT be nil!
  EXCEPTION: <NSException: 0x7fb96b3c0ed8> NAME:NSInternalInconsistencyException REASON:NGCalendarDateRange.m:37  Assertion failed in NGCalendarDateRange(instance), method initWithStartDate:endDate:.  startDate MUST NOT be nil! INFO:(null)
```

The relevant ICS file lines are the following ones:

```
  BEGIN:VEVENT
  UID:040000008200E00074C5B7101A82E00800000000901646A7234BCE01000000000000000010000000E9152C8FF1C27D488C91967FAAFCC2B0
  RECURRENCE-ID:20140513T100000Z
  DURATION:PT1H
  CLASS:PUBLIC
  ATTENDEE;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CN=krsny >>
      Ann Thierry K:mailto:krsny@example.com
  END:VEVENT
```

Suggested `NEWS` line:

* Fix recurrence pattern event corner case created by Mozilla Thunderbird which made server crash