### PR TITLE
Revert "Store c_content in sogo_cache_folder as a BLOB"

### DIFF
--- a/SoObjects/SOGo/GCSSpecialQueries+SOGoCacheObject.m
+++ b/SoObjects/SOGo/GCSSpecialQueries+SOGoCacheObject.m
@@ -57,7 +57,7 @@
        @" c_lastmodified INT4 NOT NULL,"
        @" c_version INT4 NOT NULL DEFAULT 0,"
        @" c_deleted SMALLINT NOT NULL DEFAULT 0,"
-       @" c_content BYTEA)");
+       @" c_content TEXT)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }
@@ -77,7 +77,7 @@
        @" c_lastmodified INT NOT NULL,"
        @" c_version INT NOT NULL DEFAULT 0,"
        @" c_deleted TINYINT NOT NULL DEFAULT 0,"
-       @" c_content BLOB)");
+       @" c_content LONGTEXT)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }
@@ -97,7 +97,7 @@
        @" c_lastmodified INT4 NOT NULL,"
        @" c_version INT4 NOT NULL DEFAULT 0,"
        @" c_deleted SMALLINT NOT NULL DEFAULT 0,"
-       @" c_content BLOB)");
+       @" c_content CLOB)");
 
   return [NSString stringWithFormat: sqlFolderFormat, tableName];
 }

--- a/SoObjects/SOGo/SOGoCacheGCSObject.m
+++ b/SoObjects/SOGo/SOGoCacheGCSObject.m
@@ -152,7 +152,7 @@ static EOAttribute *textColumn = nil;
 - (void) setupFromRecord: (NSDictionary *) record
 {
   NSInteger intValue;
-  NSData *content;
+  NSString *propsValue;
   NSDictionary *newValues;
 
   objectType = [[record objectForKey: @"c_type"] intValue];
@@ -166,10 +166,10 @@ static EOAttribute *textColumn = nil;
                dateWithTimeIntervalSince1970: (NSTimeInterval) intValue]);
   deleted = ([[record objectForKey: @"c_deleted"] intValue] > 0);
   version = [[record objectForKey: @"c_version"] intValue];
-  content = [record objectForKey: @"c_content"];
-  if ([content isNotNull])
+  propsValue = [record objectForKey: @"c_content"];
+  if ([propsValue isNotNull])
     {
-      newValues = [[content dataByDecodingBase64] BSONValue];
+      newValues = [[propsValue dataByDecodingBase64] BSONValue];
       [properties addEntriesFromDictionary: newValues];
     }
   else


### PR DESCRIPTION
This reverts commit b32951384568dc705d16cde4be910a886cb58b49. It was
causing issues and we'll need to do more testing on this optimisation.

This PR goes along with https://github.com/zentyal/sogo/pull/196