### PR TITLE
oc-calendar: force cache synchronisation for a message before aborting

### DIFF
--- a/OpenChange/MAPIStoreGCSFolder.h
+++ b/OpenChange/MAPIStoreGCSFolder.h
@@ -41,6 +41,7 @@
 
 /* synchronisation */
 - (BOOL) synchroniseCache;
+- (BOOL) synchroniseCacheFor: (NSString *) nameInContainer;
 - (void) updateVersionsForMessageWithKey: (NSString *) messageKey
                            withChangeKey: (NSData *) oldChangeKey
                 andPredecessorChangeList: (NSData *) pcl;

--- a/OpenChange/MAPIStoreGCSMessage.m
+++ b/OpenChange/MAPIStoreGCSMessage.m
@@ -180,7 +180,8 @@
 {
   uint64_t version = ULLONG_MAX;
   NSString *changeNumber;
- 
+  BOOL synced;
+
   if (!isNew)
     {
       changeNumber = [(MAPIStoreGCSFolder *) container
@@ -189,16 +190,28 @@
         {
           [self warnWithFormat: @"attempting to get change number"
                 @" by synchronising folder..."];
-          [(MAPIStoreGCSFolder *) container synchroniseCache];
-          changeNumber = [(MAPIStoreGCSFolder *) container
-                            changeNumberForMessageWithKey: [self nameInContainer]];
-          
-          if (changeNumber)
-            [self logWithFormat: @"got one"];
-          else
+          synced = [(MAPIStoreGCSFolder *) container synchroniseCache];
+          if (synced)
             {
-              [self errorWithFormat: @"still nothing. We crash!"];
-              abort();
+              changeNumber = [(MAPIStoreGCSFolder *) container
+                                changeNumberForMessageWithKey: [self nameInContainer]];
+            }
+          if (!changeNumber)
+            {
+              [self warnWithFormat: @"attempting to get change number"
+                    @" by synchronising this specific message..."];
+              synced = [(MAPIStoreGCSFolder *) container
+                        synchroniseCacheFor: [self nameInContainer]];
+              if (synced)
+                {
+                  changeNumber = [(MAPIStoreGCSFolder *) container
+                                  changeNumberForMessageWithKey: [self nameInContainer]];
+                }
+              if (!changeNumber)
+                {
+                  [self errorWithFormat: @"still nothing. We crash!"];
+                  abort();
+                }
             }
         }
       version = [changeNumber unsignedLongLongValue] >> 16;


### PR DESCRIPTION
Sometimes we're trying to get the `objectVersion` of a calendar message,
but this message's entry is not in the cache. The method
`synchroniseCache` won't work in this case, so we try to force the
synchronisation of that particular message in order to get the change
number before aborting.

Suggested `NEWS`:
* Avoid crashing when calendar metadata is missing in the cache