### PR TITLE
Workaround sync configure crashes

### DIFF
--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -599,7 +599,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
   uint64_t lastModseqNbr;
   EOQualifier *searchQualifier;
   NSArray *uids, *changeNumbers;
-  NSUInteger count, max;
+  NSUInteger count, max, nFetched;
   NSArray *fetchResults;
   NSDictionary *result;
   NSData *changeKey;
@@ -677,6 +677,13 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
       fetchResults
         = [fetchResults sortedArrayUsingFunction: _compareFetchResultsByMODSEQ
                                          context: NULL];
+
+      nFetched = [fetchResults count];
+      if (nFetched != max) {
+        [self errorWithFormat: @"Error fetching UIDs. Asked: %d Received: %d."
+              @"Check the IMAP conversation for details", max, nFetched];
+        return NO;
+      }
 
       for (count = 0; count < max; count++)
         {

--- a/SoObjects/Appointments/SOGoAppointmentFolder.m
+++ b/SoObjects/Appointments/SOGoAppointmentFolder.m
@@ -604,8 +604,16 @@ static Class iCalEventK = nil;
   NSNumber *classNumber;
   unsigned int grantedCount;
   iCalAccessClass currentClass;
+  WOContext *localContext;
 
-  [self initializeQuickTablesAclsInContext: context];
+  /* FIXME: The stored context from initialisation may have changed
+     by setContext by other operations in OpenChange library,
+     so we keep tighly to use the current session one. Without
+     this, the login is set to nil and a NSException is raised
+     at [SOGoAppointmentFolder:roleForComponentsWithAccessClass:forUser]
+     inside [SOGoAppointmentFolder:initializeQuickTablesAclsInContext]. */
+  localContext = [[WOApplication application] context];
+  [self initializeQuickTablesAclsInContext: localContext];
   grantedClasses = [NSMutableArray arrayWithCapacity: 3];
   deniedClasses = [NSMutableArray arrayWithCapacity: 3];
   for (currentClass = 0;


### PR DESCRIPTION
Two workarounds to avoid `NSException` as described in commit messages.

Suggested `NEWS` line in *Fixes* sections:

* Provide safe guards in mail and calendar to avoid exceptions while syncing