### PR TITLE
Do not save IPM.DistList messages

### DIFF
--- a/OpenChange/MAPIStoreContactsMessage.m
+++ b/OpenChange/MAPIStoreContactsMessage.m
@@ -1024,10 +1024,12 @@ fromProperties: (NSDictionary *) attachmentProps
           || (!isNew && [roles containsObject: SOGoRole_ObjectEditor]));
 }
 
-//
-//
-//
-- (void) save:(TALLOC_CTX *) memCtx
+- (void) saveDistList:(TALLOC_CTX *) memCtx
+{
+  [self warnWithFormat: @"IPM.DistList messages are ignored"];
+}
+
+- (void) saveContact:(TALLOC_CTX *) memCtx
 {
   NSArray *elements, *units;
   CardElement *element;
@@ -1372,5 +1374,15 @@ fromProperties: (NSDictionary *) attachmentProps
 
   [self updateVersions];
 }
+
+- (void) save:(TALLOC_CTX *) memCtx
+{
+  NSString *messageClass = [properties objectForKey: MAPIPropertyKey(PR_MESSAGE_CLASS_UNICODE)];
+  if ([messageClass isEqualToString: @"IPM.DistList"])
+    [self saveDistList: memCtx];
+  else
+    [self saveContact: memCtx]; 
+}
+
 
 @end

--- a/OpenChange/MAPIStoreGCSMessage.m
+++ b/OpenChange/MAPIStoreGCSMessage.m
@@ -140,9 +140,16 @@
           [parentFolder synchroniseCache];
           changeKey = [parentFolder changeKeyForMessageWithKey: nameInContainer];
         }
-      if (!changeKey)
-        abort ();
-      *data = [changeKey asBinaryInMemCtx: memCtx];
+      if (changeKey)
+        *data = [changeKey asBinaryInMemCtx: memCtx];
+      else
+        {
+          [self warnWithFormat: @"No change key for %@ in folder %@",
+                nameInContainer,
+                [parentFolder url]
+           ];
+          rc = MAPISTORE_ERR_NOT_FOUND;
+        }
     }
 
   return rc;


### PR DESCRIPTION
This is a temporal solution until we have support of IMP.DistList. 
Not saving them avoid the creation of a incorrect contact in SOGo with the name of the distribution list. The member of the distribution list are correctly imported.

The distribution list created in SOGo are ignored.

Suggested NEWS line:

    Avoid creation of phantom contacts in SOGo from distribution list synced from Outlook.
