### PR TITLE
Fix unpropagated return values in SOGoContentObject

### DIFF
--- a/SoObjects/SOGo/SOGoContentObject.m
+++ b/SoObjects/SOGo/SOGoContentObject.m
@@ -246,14 +246,12 @@
 
 - (NSException *) copyToFolder: (SOGoGCSFolder *) newFolder
 {
-  [self subclassResponsibility: _cmd];
-
-  return nil;
+  return [self subclassResponsibility: _cmd];
 }
 
 - (NSException *) moveToFolder: (SOGoGCSFolder *) newFolder
 {
-  [self subclassResponsibility: _cmd];
+  return [self subclassResponsibility: _cmd];
 }
 
 - (NSException *) delete


### PR DESCRIPTION
The methods moveToFolder: and copyToFolder: are responsability
of subclasses of SOGoContentObject but their return values
were not propagated.