### PR TITLE
sogo-openchange: Avoid compile warnings after changes in exchange.idl

### DIFF
--- a/OpenChange/MAPIStoreDBFolder.m
+++ b/OpenChange/MAPIStoreDBFolder.m
@@ -102,7 +102,7 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
     {
       value = get_SPropValue_SRow (aRow, PidTagDisplayName_string8);
       if (value)
-        folderName = [NSString stringWithUTF8String: value->value.lpszA];
+        folderName = [NSString stringWithUTF8String: (const char *) value->value.lpszA];
       else
         folderName = nil;
     }

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -181,7 +181,7 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
       if (aRow->lpProps[i].ulPropTag == PR_DISPLAY_NAME_UNICODE)
         folderName = [NSString stringWithUTF8String: aRow->lpProps[i].value.lpszW];
       else if (aRow->lpProps[i].ulPropTag == PR_DISPLAY_NAME)
-        folderName = [NSString stringWithUTF8String: aRow->lpProps[i].value.lpszA];
+        folderName = [NSString stringWithUTF8String: (const char *) aRow->lpProps[i].value.lpszA];
     }
 
   if (folderName)

--- a/OpenChange/MAPIStoreTypes.m
+++ b/OpenChange/MAPIStoreTypes.m
@@ -198,7 +198,7 @@ NSObjectFromSPropValue (const struct SPropValue *value)
       break;
     case PT_STRING8:
       result = (value->value.lpszA
-                ? [NSString stringWithUTF8String: value->value.lpszA]
+                ? [NSString stringWithUTF8String: (const char *) value->value.lpszA]
                 : (id) @"");
       break;
     case PT_SYSTIME:

--- a/OpenChange/NSArray+MAPIStore.m
+++ b/OpenChange/NSArray+MAPIStore.m
@@ -228,7 +228,7 @@
   mvResult = [NSMutableArray arrayWithCapacity: mvString->cValues];
   for (count = 0; count < mvString->cValues; count++)
     {
-      subObject = [NSString stringWithUTF8String: mvString->lppszA[count]];
+      subObject = [NSString stringWithUTF8String: (const char *) mvString->lppszA[count]];
       [mvResult addObject: subObject];
     }
 


### PR DESCRIPTION
The changes in the exchange.idl file from OpenChange has changed
some string pointers from 'const char *' to 'uint8_t *'.
This changeset cast them to avoid compilation warnings.