### PR TITLE
User context activation when cached

### DIFF
--- a/OpenChange/MAPIStoreUserContext.m
+++ b/OpenChange/MAPIStoreUserContext.m
@@ -73,6 +73,8 @@ static NSMapTable *contextsTable = nil;
       [userContext autorelease];
       [contextsTable setObject: userContext forKey: username];
     }
+  else
+    [userContext activate];
 
   return userContext;
 }

--- a/SoObjects/SOGo/SOGoObject.m
+++ b/SoObjects/SOGo/SOGoObject.m
@@ -180,6 +180,9 @@
         [NSException raise: NSInvalidArgumentException
                      format: @"'_name' must not be an empty string"];
       context = [[WOApplication application] context];
+      if (!context)
+        [self errorWithFormat: @"Error: initializing a SOGoObject (named %@) "
+                               @"without wocontext", _name];
       nameInContainer = [_name copy];
       container = _container;
       if ([self doesRetainContainer])


### PR DESCRIPTION
Fix cfab18e so user context is always activated when using userContextWithUsername method and add a log message to catch more operations when objects are created badly with woContext of the woApplication set to nil