### PR TITLE
Adapt to new safe_ldb_search function

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -266,7 +266,7 @@ static NSCharacterSet *hexCharacterSet = nil;
             {
               username = [contactInfos objectForKey: @"sAMAccountName"];
               recipient->username = [username asUnicodeInMemCtx: msgData];
-              entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
+              entryId = MAPIStoreInternalEntryId (connInfo, username);
             }
           else
             {
@@ -367,7 +367,7 @@ static NSCharacterSet *hexCharacterSet = nil;
           {
             username = [contactInfos objectForKey: @"sAMAccountName"];
             recipient->username = [username asUnicodeInMemCtx: msgData];
-            entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
+            entryId = MAPIStoreInternalEntryId (connInfo, username);
           }
         else
           {
@@ -932,7 +932,7 @@ static NSCharacterSet *hexCharacterSet = nil;
   if (contactInfos)
     {
       username = [contactInfos objectForKey: @"sAMAccountName"];
-      entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, username);
+      entryId = MAPIStoreInternalEntryId (connInfo, username);
     }
   else
     entryId = MAPIStoreExternalEntryId (cn, email);

--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -1549,7 +1549,6 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   struct Binary_r bin32;
   struct AddressBookEntryId *entryId;
   NSString *username;
-  struct ldb_context *samCtx;
 
   if (bin && bin->cb)
     {
@@ -1559,8 +1558,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
       entryId = get_AddressBookEntryId (NULL, &bin32);
       if (entryId)
         {
-          samCtx = [[self context] connectionInfo]->sam_ctx;
-          username = MAPIStoreSamDBUserAttribute (samCtx, @"legacyExchangeDN",
+          username = MAPIStoreSamDBUserAttribute ([[self context] connectionInfo],
+                                                  @"legacyExchangeDN",
                                                   [NSString stringWithUTF8String: entryId->X500DN],
                                                   @"sAMAccountName");
         }

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -811,7 +811,6 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   NSDictionary *contactInfos;
   NGMailAddress *ngAddress;
   NSData *entryId;
-  struct ldb_context *samCtx;
   int rc;
 
   if (fullMail)
@@ -834,8 +833,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
       if (contactInfos)
         {
           username = [contactInfos objectForKey: @"sAMAccountName"];
-          samCtx = [[self context] connectionInfo]->sam_ctx;
-          entryId = MAPIStoreInternalEntryId (samCtx, username);
+          entryId = MAPIStoreInternalEntryId([[self context] connectionInfo], username);
         }
       else
         entryId = MAPIStoreExternalEntryId (cn, email);
@@ -1478,11 +1476,9 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   NSData *entryId;
   NSDictionary *contactInfos;
   SOGoUserManager *mgr;
-  struct ldb_context *samCtx;
   struct mapistore_message *msgData;
   struct mapistore_message_recipient *recipient;
 
-  samCtx = [[self context] connectionInfo]->sam_ctx;
   [super getMessageData: &msgData inMemCtx: memCtx];
 
   if (!headerSetup)
@@ -1536,7 +1532,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
                     {
                       username = [contactInfos objectForKey: @"sAMAccountName"];
                       recipient->username = [username asUnicodeInMemCtx: msgData];
-                      entryId = MAPIStoreInternalEntryId (samCtx, username);
+                      entryId = MAPIStoreInternalEntryId ([[self context] connectionInfo], username);
                     }
                   else
                     {

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -338,12 +338,9 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
   NSData *entryId;
   NSDictionary *allRecipients, *dict, *contactInfos;
   SOGoUserManager *mgr;
-  struct ldb_context *samCtx;
   struct mapistore_message *msgData;
   struct mapistore_message_recipient *recipient;
   enum ulRecipClass type;
-
-  samCtx = [[self context] connectionInfo]->sam_ctx;
 
   // [super getMessageData: &msgData inMemCtx: memCtx];
 
@@ -389,7 +386,7 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
             {
               username = [contactInfos objectForKey: @"sAMAccountName"];
               recipient->username = [username asUnicodeInMemCtx: msgData];
-              entryId = MAPIStoreInternalEntryId (samCtx, username);
+              entryId = MAPIStoreInternalEntryId ([[self context] connectionInfo], username);
             }
           else
             {
@@ -700,7 +697,7 @@ FillMessageHeadersFromProperties (NGMutableHashMap *headers,
                                    hasSuffix: @"08002b2fe182"])
             {
               /* TODO: better way to distinguish local and other ones */
-              username = MAPIStoreSamDBUserAttribute (connInfo->sam_ctx, @"legacyExchangeDN",
+              username = MAPIStoreSamDBUserAttribute (connInfo, @"legacyExchangeDN",
                                                       [NSString stringWithUTF8String: addrBookEntryId->X500DN], @"sAMAccountName");
               if (username)
                 {
@@ -1008,7 +1005,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
 - (NGMimeMessage *) _generateMessageWithBcc: (BOOL) withBcc
 {
   NSString *contentType;
-  NGMimeMessage *message;  
+  NGMimeMessage *message;
   NGMutableHashMap *headers;
   id messageBody;
 

--- a/OpenChange/MAPIStorePermissionsTable.m
+++ b/OpenChange/MAPIStorePermissionsTable.m
@@ -103,7 +103,7 @@
   else
     {
       connInfo = [(MAPIStoreContext *) [container context] connectionInfo];
-      entryId = MAPIStoreInternalEntryId (connInfo->sam_ctx, userId);
+      entryId = MAPIStoreInternalEntryId (connInfo, userId);
     }
   *data = [entryId asBinaryInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreSamDBUtils.h
+++ b/OpenChange/MAPIStoreSamDBUtils.h
@@ -25,13 +25,13 @@
 
 @class NSString;
 
-struct ldb_context;
+#include <mapistore/mapistore.h>
 
-NSString *MAPIStoreSamDBUserAttribute (struct ldb_context *samCtx,
+NSString *MAPIStoreSamDBUserAttribute (struct mapistore_connection_info *connInfo,
                                        NSString *userKey,
                                        NSString *value,
                                        NSString *attributeName);
-NSData *MAPIStoreInternalEntryId (struct ldb_context *, NSString *username);
+NSData *MAPIStoreInternalEntryId (struct mapistore_connection_info *connInfo, NSString *username);
 NSData *MAPIStoreExternalEntryId (NSString *cn, NSString *email);
 
 #endif /* MAPISTORESAMDBUTILS_H */

--- a/OpenChange/MAPIStoreSamDBUtils.m
+++ b/OpenChange/MAPIStoreSamDBUtils.m
@@ -24,13 +24,17 @@
 #import <Foundation/NSString.h>
 #include <talloc.h>
 #include <ldb.h>
+#include <libmapiproxy.h>
 
 #import "NSData+MAPIStore.h"
 
 #import "MAPIStoreSamDBUtils.h"
 
+
+
+
 NSString *
-MAPIStoreSamDBUserAttribute (struct ldb_context *samCtx,
+MAPIStoreSamDBUserAttribute (struct mapistore_connection_info *connInfo,
                              NSString *userKey,
                              NSString *value,
                              NSString *attributeName)
@@ -48,10 +52,11 @@ MAPIStoreSamDBUserAttribute (struct ldb_context *samCtx,
   attrs[0] = [attributeName UTF8String];
   searchFormat
     = [NSString stringWithFormat: @"(&(objectClass=user)(%@=%%s))", userKey];
-  ret = ldb_search (samCtx, memCtx, &res, ldb_get_default_basedn(samCtx),
-                    LDB_SCOPE_SUBTREE, attrs,
-                    [searchFormat UTF8String],
-                    [value UTF8String]);
+  ret = safe_ldb_search(&connInfo->sam_ctx, memCtx, &res,
+                        ldb_get_default_basedn(connInfo->sam_ctx),
+                        LDB_SCOPE_SUBTREE, attrs,
+                        [searchFormat UTF8String],
+                        [value UTF8String]);
   if (ret == LDB_SUCCESS && res->count == 1)
     {
       result = ldb_msg_find_attr_as_string (res->msgs[0], attrs[0], NULL);
@@ -65,7 +70,7 @@ MAPIStoreSamDBUserAttribute (struct ldb_context *samCtx,
 }
 
 NSData *
-MAPIStoreInternalEntryId (struct ldb_context *samCtx, NSString *username)
+MAPIStoreInternalEntryId (struct mapistore_connection_info *connInfo, NSString *username)
 {
   static const uint8_t const providerUid[] = { 0xdc, 0xa7, 0x40, 0xc8,
                                                0xc0, 0x42, 0x10, 0x1a,
@@ -82,7 +87,7 @@ MAPIStoreInternalEntryId (struct ldb_context *samCtx, NSString *username)
      type: 32
      X500DN: variable */
 
-  legacyDN = MAPIStoreSamDBUserAttribute (samCtx, @"sAMAccountName", username,
+  legacyDN = MAPIStoreSamDBUserAttribute (connInfo, @"sAMAccountName", username,
                                           @"legacyExchangeDN");
   if (legacyDN)
     {


### PR DESCRIPTION
Adapt to new OpenChange safe method to avoid freeing
connInfo->samCtx without replacing it with a new one on
reconnect events