### PR TITLE
Priorize filename attribute first to get attachment name

### DIFF
--- a/SoObjects/Mailer/NSDictionary+Mail.m
+++ b/SoObjects/Mailer/NSDictionary+Mail.m
@@ -30,14 +30,13 @@
 {
   NSDictionary *parameters;
   NSString *filename;
-  
-  filename = [[self objectForKey: @"parameterList"]
-	       objectForKey: @"name"];
-  
-  if (!filename)
+
+  filename = nil;
+  parameters = [[self objectForKey: @"disposition"]
+                    objectForKey: @"parameterList"];
+
+  if (parameters)
     {
-      parameters = [[self objectForKey: @"disposition"]
-		     objectForKey: @"parameterList"];
       filename = [parameters objectForKey: @"filename"];
 
 
@@ -45,28 +44,32 @@
       // See RFC2231 for details. If it was folded before, it will
       // be unfolded when we get here.
       if (!filename)
-	{
-	  filename = [parameters objectForKey: @"filename*"];
-	  
-	  if (filename)
-	    {
-	      NSRange r;
-	      
-	      filename = [filename stringByUnescapingURL];
-	      
-	      // We skip up to the language
-	      r = [filename rangeOfString: @"'"];
-	      
-	      if (r.length)
-		{
-		  r = [filename rangeOfString: @"'"  options: 0  range: NSMakeRange(r.location+1, [filename length]-r.location-1)];
-		  
-		  if (r.length)
-		    filename = [filename substringFromIndex: r.location+1];
-		}
-	    }
-	}
+        {
+          filename = [parameters objectForKey: @"filename*"];
+          
+          if (filename)
+            {
+              NSRange r;
+              
+              filename = [filename stringByUnescapingURL];
+              
+              // We skip up to the language
+              r = [filename rangeOfString: @"'"];
+              
+              if (r.length)
+                {
+                  r = [filename rangeOfString: @"'"  options: 0  range: NSMakeRange(r.location+1, [filename length]-r.location-1)];
+                  
+                  if (r.length)
+                    filename = [filename substringFromIndex: r.location+1];
+                }
+            }
+        }
     }
+
+  if (!filename)
+    filename = [[self objectForKey: @"parameterList"]
+                 objectForKey: @"name"];
 
   return filename;
 }


### PR DESCRIPTION
Some clients (like apple mail) use only the filename
attribute in the content/disposition header and the
name attribute from the content/type header is fill with
uninternationalized characters. Example: "___.rtf".

This changeset give priority to the filename attribute.