### PR TITLE
Manage multiple Change Number restrictions

### DIFF
--- a/OpenChange/MAPIStoreDBMessage.m
+++ b/OpenChange/MAPIStoreDBMessage.m
@@ -109,6 +109,49 @@
   return self;
 }
 
+- (NSString *) description
+{
+  id key, value;
+  NSEnumerator *propEnumerator;
+  NSMutableString *description;
+
+  description = [NSMutableString stringWithFormat: @"%@ %@. Properties: {", NSStringFromClass ([self class]),
+                                 [self url]];
+
+  propEnumerator = [properties keyEnumerator];
+  while ((key = [propEnumerator nextObject]))
+    {
+      uint32_t proptag = 0;
+      if ([key isKindOfClass: [NSString class]] && [(NSString *)key intValue] > 0)
+        proptag = [(NSString *)key intValue];
+      else if ([key isKindOfClass: [NSNumber class]])
+        proptag = [key unsignedLongValue];
+
+      if (proptag > 0)
+        {
+          const char *propTagName = get_proptag_name ([key unsignedLongValue]);
+          NSString *propName;
+
+          if (propTagName)
+            propName = [NSString stringWithCString: propTagName
+                                          encoding: NSUTF8StringEncoding];
+          else
+            propName = [NSString stringWithFormat: @"0x%.4x", [key unsignedLongValue]];
+
+          [description appendFormat: @"'%@': ", propName];
+        }
+      else
+        [description appendFormat: @"'%@': ", key];
+
+      value = [properties objectForKey: key];
+      [description appendFormat: @"%@ (%@), ", value, NSStringFromClass ([value class])];
+    }
+
+  [description appendString: @"}\n"];
+
+  return description;
+}
+
 - (uint64_t) objectVersion
 {
   NSNumber *versionNbr;

--- a/OpenChange/MAPIStoreDBMessageTable.m
+++ b/OpenChange/MAPIStoreDBMessageTable.m
@@ -61,14 +61,15 @@ static Class MAPIStoreDBMessageK = Nil;
 
   if ((uint32_t) res->ulPropTag == PidTagChangeNumber)
     {
+      SEL operator;
+
       value = NSObjectFromMAPISPropValue (&res->lpProp);
       cVersion = exchange_globcnt (([value unsignedLongLongValue] >> 16)
                                    & 0x0000ffffffffffffLL);
       version = [NSNumber numberWithUnsignedLongLong: cVersion];
-      //[self logWithFormat: @"change number from oxcfxics: %.16lx", [value unsignedLongLongValue]];
-      [self logWithFormat: @"  version: %.16lx", cVersion];
-      *qualifier = [[EOKeyValueQualifier alloc] initWithKey: @"version"
-                                           operatorSelector: EOQualifierOperatorGreaterThanOrEqualTo
+      operator = [self operatorFromRestrictionOperator: res->relop];
+      *qualifier = [[EOKeyValueQualifier alloc] initWithKey: @"version_number"
+                                           operatorSelector: operator
                                                       value: version];
       [*qualifier autorelease];
       rc = MAPIRestrictionStateNeedsEval;

--- a/OpenChange/MAPIStoreGCSFolder.m
+++ b/OpenChange/MAPIStoreGCSFolder.m
@@ -681,12 +681,12 @@ static Class NSNumberK;
 - (NSNumber *) lastModifiedFromMessageChangeNumber: (NSString *) changeNumber
 {
   NSDictionary *mapping;
-  NSNumber *modseq;
+  NSNumber *lastModified;
 
   mapping = [[versionsMessage properties] objectForKey: @"VersionMapping"];
-  modseq = [mapping objectForKey: changeNumber];
+  lastModified = [mapping objectForKey: changeNumber];
 
-  return modseq;
+  return lastModified;
 }
 
 - (NSString *) changeNumberForMessageWithKey: (NSString *) messageKey

--- a/OpenChange/MAPIStoreGCSMessageTable.m
+++ b/OpenChange/MAPIStoreGCSMessageTable.m
@@ -99,14 +99,21 @@
       //[self logWithFormat: @"  c_lastmodified: %@", lastModified];
       if (lastModified)
         {
+          SEL operator;
+
+          operator = [self operatorFromRestrictionOperator: res->relop];
           *qualifier = [[EOKeyValueQualifier alloc] initWithKey: @"c_lastmodified"
-                                               operatorSelector: EOQualifierOperatorGreaterThanOrEqualTo
+                                               operatorSelector: operator
                                                           value: lastModified];
           [*qualifier autorelease];
           rc = MAPIRestrictionStateNeedsEval;
         }
       else
-        rc = MAPIRestrictionStateAlwaysTrue;
+        {
+          [self logWithFormat: @"No last modified found for: 0x%.16"PRIx64". Then no restriction applied",
+                [value unsignedLongLongValue]];
+          rc = MAPIRestrictionStateAlwaysTrue;
+        }
     }
   else
     {

--- a/OpenChange/MAPIStoreGCSMessageTable.m
+++ b/OpenChange/MAPIStoreGCSMessageTable.m
@@ -27,6 +27,7 @@
 #import <Foundation/NSString.h>
 
 #import <NGExtensions/NSObject+Logs.h>
+#import <NGExtensions/NSObject+Values.h>
 
 #import <EOControl/EOFetchSpecification.h>
 #import <EOControl/EOQualifier.h>
@@ -38,7 +39,6 @@
 
 #import "MAPIStoreTypes.h"
 #import "MAPIStoreGCSFolder.h"
-
 #import "MAPIStoreGCSMessageTable.h"
 
 #undef DEBUG
@@ -89,9 +89,12 @@
 
   if (res->ulPropTag == PidTagChangeNumber)
     {
+      NSString *changeNumber;
+
       value = NSObjectFromMAPISPropValue (&res->lpProp);
+      changeNumber = [NSString stringWithUnsignedLongLong: [(NSNumber *)value unsignedLongLongValue]];
       lastModified = [(MAPIStoreGCSFolder *)
-                       container lastModifiedFromMessageChangeNumber: value];
+                       container lastModifiedFromMessageChangeNumber: changeNumber];
       //[self logWithFormat: @"change number from oxcfxics: %.16lx", [value unsignedLongLongValue]];
       //[self logWithFormat: @"  c_lastmodified: %@", lastModified];
       if (lastModified)

--- a/OpenChange/MAPIStoreMailMessageTable.m
+++ b/OpenChange/MAPIStoreMailMessageTable.m
@@ -181,8 +181,8 @@ static Class MAPIStoreMailMessageK, NSDataK, NSStringK;
         else
           {
             /* Ignore other operations as IMAP only support MODSEQ >= X */
-            [self warnWithFormat: @"Ignoring %@ as only supported operators are > and >=",
-                  [self operatorFromRestrictionOperator: res->relop]];
+            [self warnWithFormat: @"Ignoring '%@' as only supported operators are > and >=",
+                  NSStringFromSelector ([self operatorFromRestrictionOperator: res->relop])];
             rc = MAPIRestrictionStateAlwaysTrue;
           }
       }

--- a/OpenChange/MAPIStoreSOGoObject.m
+++ b/OpenChange/MAPIStoreSOGoObject.m
@@ -197,6 +197,7 @@ static Class MAPIStoreFolderK;
                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   int rc;
+  struct mapistore_connection_info *connInfo;
   uint64_t obVersion;
 
   obVersion = [self objectVersion];
@@ -204,8 +205,9 @@ static Class MAPIStoreFolderK;
     rc = MAPISTORE_ERR_NOT_FOUND;
   else
     {
+      connInfo = [[self context] connectionInfo];
       *data = MAPILongLongValue (memCtx, ((obVersion << 16)
-                                          | 0x0001));
+                                          | connInfo->repl_id));
       rc = MAPISTORE_SUCCESS;
     }
 


### PR DESCRIPTION
Most of these changes make only sense along with https://github.com/zentyal/openchange/pull/189.

Along with the support to all kind of messages (Mail, GCS and DB) we have added several fixes:

* Use ReplicaID from connection info to build the `ChangeNumber` and `ChangeKey` properties
* Use NSString index for version lookup in GCS messages (Calendar, Task, Contacts) when searching for a last modified value using the Change Number
* Implement description method for `MAPIStoreDBMessage` to ease debugging.

The `NEWS` tip would be in `Enhancements` section:

* Return the requested elements on complex requests from Outlook when downloading changes