### PR TITLE
oc: Dump property canonical name in dbmsgreader

### DIFF
--- a/OpenChange/GNUmakefile
+++ b/OpenChange/GNUmakefile
@@ -145,7 +145,8 @@ $(DBMSGREADER_TOOL)_LIB_DIRS += \
 	-L../SoObjects/SOGo/SOGo.framework/sogo -lSOGo \
 	-L../SOPE/GDLContentStore/obj/ -lGDLContentStore \
 	-L../SOPE/NGCards/obj/ -lNGCards \
-	-lNGObjWeb
+	-lNGObjWeb \
+	$(LIBMAPI_LIBS)
 
 TEST_TOOL_NAME += $(PLREADER_TOOL) $(DBMSGREADER_TOOL)
 


### PR DESCRIPTION
Example:

```
{ 18 items
  PidTagSubjectPrefix = (GSCBufferString) ,
  PidTagSearchKey = (NSDataMalloc) <b97455a5 d2752443 8d56a69f 9da90f8c>,
  PidTagLastModificationTime = (NSCalendarDate) 2015-12-10 06:41:04 -0800,
  PidTagCreationTime = (NSCalendarDate) 2015-12-10 06:41:04 -0800,
  PidTagNormalizedSubject = (GSCBufferString) IPM.Configuration.RssRule,
  PidTagRoamingDatatypes = (NSIntNumber) 4,
  PidTagMessageFlags = (NSIntNumber) 73,
  0x685d0003 = (NSIntNumber) 785437,
  PidTagSensitivity = (NSIntNumber) 0,
  PidTagRtfInSync = (NSIntNumber) 1,
  PidTagLastModifierName = (GSCBufferString) foo@foobar.lan,
  PidTagRoamingDictionary = (NSDataMalloc) <3c3f786d 6c207665 7273696f 6e3d2231 2e30223f 3e0d0a3c 55736572 436f6e66 69677572 6174696f 6e3e0d0a 093c496e 666f2076 65727369 6f6e3d22 4f75746c 6f6f6b2e 3134222f 3e0d0a09 3c446174 613e0d0a 09093c65 206b3d22 31382d70 6952756c 654f6e41 6c6c5273 73222076 3d22332d 46616c73 65222f3e 0d0a0909 3c65206b 3d223138 2d4f4c50 72656673 56657273 696f6e22 20763d22 392d3122 2f3e0d0a 093c2f44 6174613e 0d0a3c2f 55736572 436f6e66 69677572 6174696f 6e3e0d0a>,
  PidTagMessageClass = (GSCBufferString) IPM.Configuration.RssRule,
  version_number = (NSIntNumber) 875,
  PidTagSourceKey = (NSDataMalloc) <de7f32ab 10dde643 81697c0a 56bd0f06 00000001 4b10>,
  PidTagImportance = (NSIntNumber) 1,
  PidTagPredecessorChangeList = (NSDataMalloc) <14379914 02c48399 4b9b56be 96df1df7 11000004 0d16de7f 32ab10dd e6438169 7c0a56bd 0f060000 0000036b>,
  PidTagChangeKey = (NSDataMalloc) <37991402 c483994b 9b56be96 df1df711 0000040d>,
}
```