### PR TITLE
oc-calendar: Use the time zone provided by the client

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.h
+++ b/OpenChange/MAPIStoreAppointmentWrapper.h
@@ -24,6 +24,7 @@
 #define MAPISTORECALENDARWRAPPER_H
 
 #import <NGCards/iCalPerson.h>
+#import <NGCards/iCalTimeZone.h>
 #import <Appointments/iCalEntityObject+SOGo.h>
 
 #import "MAPIStoreObjectProxy.h"
@@ -42,7 +43,7 @@
   iCalCalendar *calendar;
   iCalEvent *firstEvent;
   iCalEvent *event;
-  NSTimeZone *timeZone;
+  iCalTimeZone *timeZone;
   SOGoUser *user;
   NSString *senderEmail;
   NSData *globalObjectId;
@@ -57,12 +58,10 @@
 + (id) wrapperWithICalEvent: (iCalEvent *) newEvent
                     andUser: (SOGoUser *) newUser
              andSenderEmail: (NSString *) newSenderEmail
-                 inTimeZone: (NSTimeZone *) newTimeZone
          withConnectionInfo: (struct mapistore_connection_info *) newConnInfo;
 - (id) initWithICalEvent: (iCalEvent *) newEvent
                  andUser: (SOGoUser *) newUser
           andSenderEmail: (NSString *) newSenderEmail
-              inTimeZone: (NSTimeZone *) newTimeZone
       withConnectionInfo: (struct mapistore_connection_info *) newConnInfo;
 
 /* getters */

--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -37,7 +37,9 @@
 #import <NGCards/iCalEventChanges.h>
 #import <NGCards/iCalPerson.h>
 #import <NGCards/iCalTrigger.h>
+#import <NGCards/iCalTimeZonePeriod.h>
 #import <NGCards/NSString+NGCards.h>
+#import <SOGo/SOGoDomainDefaults.h>
 #import <SOGo/SOGoUser.h>
 #import <SOGo/SOGoUserManager.h>
 
@@ -80,7 +82,6 @@ static NSCharacterSet *hexCharacterSet = nil;
 + (id) wrapperWithICalEvent: (iCalEvent *) newEvent
                     andUser: (SOGoUser *) newUser
              andSenderEmail: (NSString *) newSenderEmail
-                 inTimeZone: (NSTimeZone *) newTimeZone
          withConnectionInfo: (struct mapistore_connection_info *) newConnInfo
 {
   MAPIStoreAppointmentWrapper *wrapper;
@@ -88,7 +89,6 @@ static NSCharacterSet *hexCharacterSet = nil;
   wrapper = [[self alloc] initWithICalEvent: newEvent
                                     andUser: newUser
                              andSenderEmail: newSenderEmail
-                                 inTimeZone: newTimeZone
                          withConnectionInfo: newConnInfo];
   [wrapper autorelease];
 
@@ -182,10 +182,10 @@ static NSCharacterSet *hexCharacterSet = nil;
 - (id) initWithICalEvent: (iCalEvent *) newEvent
                  andUser: (SOGoUser *) newUser
           andSenderEmail: (NSString *) newSenderEmail
-              inTimeZone: (NSTimeZone *) newTimeZone
       withConnectionInfo: (struct mapistore_connection_info *) newConnInfo
 {
   NSArray *events;
+  iCalTimeZone *tz;
 
   if ((self = [self init]))
     {
@@ -194,9 +194,20 @@ static NSCharacterSet *hexCharacterSet = nil;
       event = newEvent;
       events = [calendar events];
       firstEvent = [events objectAtIndex: 0];
-      ASSIGN (timeZone, newTimeZone);
       ASSIGN (user, newUser);
       ASSIGN (senderEmail, newSenderEmail);
+      /* If newEvent comes from the client, we set its time zone in
+         updateFromMAPIProperties. If it is not present, we use the
+         time zone of the user */
+      tz = (iCalTimeZone *) [calendar firstChildWithTag: @"vtimezone"];
+      if (!tz)
+        {
+          tz = [iCalTimeZone timeZoneForName: [[[user userDefaults] timeZone] name]];
+          if (!tz)
+            [self logWithFormat: @"no time zone could be set"];
+	}
+      ASSIGN (timeZone, tz);
+
       [self _setupITIPContext];
     }
 
@@ -721,22 +732,15 @@ static NSCharacterSet *hexCharacterSet = nil;
                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
-  NSInteger offset;
 
   // if ([event isRecurrent])
   //   dateValue = [event firstRecurrenceStartDate];
   // else
   dateValue = [event startDate];
   if ([event isAllDay])
-    {
-      offset = -[timeZone secondsFromGMTForDate: dateValue];
-      dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                         hours: 0 minutes: 0
-                                       seconds: offset];
-    }
-  [dateValue setTimeZone: utcTZ];
+    dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
   *data = [dateValue asFileTimeInMemCtx: memCtx];
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -749,22 +753,14 @@ static NSCharacterSet *hexCharacterSet = nil;
      exceptions, where it is the normal start date for the day of the
      exception. */
   NSCalendarDate *dateValue;
-  NSInteger offset;
 
   dateValue = [event recurrenceId];
   if (!dateValue)
     dateValue = [event startDate];
-  [dateValue setTimeZone: timeZone];
   if ([event isAllDay])
-    {
-      offset = -[timeZone secondsFromGMTForDate: dateValue];
-      dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                         hours: 0 minutes: 0
-                                       seconds: offset];
-    }
-  [dateValue setTimeZone: utcTZ];
+    dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
   *data = [dateValue asFileTimeInMemCtx: memCtx];
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -772,19 +768,12 @@ static NSCharacterSet *hexCharacterSet = nil;
                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
-  NSInteger offset;
 
   dateValue = [firstEvent startDate];
   if ([firstEvent isAllDay])
-    {
-      offset = -[timeZone secondsFromGMTForDate: dateValue];
-      dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                         hours: 0 minutes: 0
-                                       seconds: offset];
-    }
-  [dateValue setTimeZone: utcTZ];
+    dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
   *data = [dateValue asFileTimeInMemCtx: memCtx];
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -804,8 +793,8 @@ static NSCharacterSet *hexCharacterSet = nil;
                                          month: [start monthOfYear]
                                            day: [start dayOfMonth]
                                           hour: 0 minute: 0 second: 0
-                                      timeZone: timeZone];
-      [dateValue setTimeZone: utcTZ];
+                                      timeZone: utcTZ];
+      dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
       *data = [dateValue asFileTimeInMemCtx: memCtx];
       rc = MAPISTORE_SUCCESS;
     }
@@ -829,7 +818,7 @@ static NSCharacterSet *hexCharacterSet = nil;
   dateValue = [event startDate];
   offset = [event durationAsTimeInterval];
   if ([event isAllDay])
-    offset -= [timeZone secondsFromGMTForDate: dateValue];
+    offset -= [[timeZone periodForDate: dateValue] secondsOffsetFromGMT];
   dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
                                      hours: 0 minutes: 0
                                    seconds: offset];
@@ -847,15 +836,14 @@ static NSCharacterSet *hexCharacterSet = nil;
   dateValue = [event recurrenceId];
   if (!dateValue)
     dateValue = [event startDate];
-  [dateValue setTimeZone: timeZone];
   offset = [firstEvent durationAsTimeInterval];
   if ([firstEvent isAllDay])
-    offset -= [timeZone secondsFromGMTForDate: dateValue];
+    offset -= [[timeZone periodForDate: dateValue] secondsOffsetFromGMT];
   dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
                                      hours: 0 minutes: 0
                                    seconds: offset];
   *data = [dateValue asFileTimeInMemCtx: memCtx];
-  
+
   return MAPISTORE_SUCCESS;
 }
 
@@ -871,7 +859,7 @@ static NSCharacterSet *hexCharacterSet = nil;
   dateValue = [firstEvent startDate];
   offset = [firstEvent durationAsTimeInterval];
   if ([event isAllDay])
-    offset -= [timeZone secondsFromGMTForDate: dateValue];
+    offset -= [[timeZone periodForDate: dateValue] secondsOffsetFromGMT];
   dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
                                      hours: 0 minutes: 0
                                    seconds: offset];
@@ -885,23 +873,14 @@ static NSCharacterSet *hexCharacterSet = nil;
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
-  NSInteger offset;
   iCalRecurrenceRule *rrule;
 
   if ([event isRecurrent])
     {
       rrule = [[event recurrenceRules] objectAtIndex: 0];
       dateValue = [rrule untilDate];
-      if (dateValue)
-        {
-          if ([event isAllDay])
-            offset = -[timeZone secondsFromGMTForDate: dateValue];
-          else
-            offset = 0;
-          dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                             hours: 0 minutes: 0
-                                           seconds: offset];
-        }
+      if (dateValue && [event isAllDay])
+        dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
       else
         dateValue = [NSCalendarDate dateWithYear: 4500 month: 8 day: 31
                                             hour: 23 minute: 59 second: 00
@@ -1338,21 +1317,14 @@ static NSCharacterSet *hexCharacterSet = nil;
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
-  NSInteger offset;
 
   dateValue = [event recurrenceId];
   if (dateValue)
     {
       rc = MAPISTORE_SUCCESS;
-      
+
       if ([event isAllDay])
-        {
-          offset = -[timeZone secondsFromGMTForDate: dateValue];
-          dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                             hours: 0 minutes: 0
-                                           seconds: offset];
-        }
-      [dateValue setTimeZone: utcTZ];
+        dateValue = [timeZone shiftedCalendarDateForDate: dateValue];
       *data = [dateValue asFileTimeInMemCtx: memCtx];
     }
   else
@@ -1377,7 +1349,6 @@ static NSCharacterSet *hexCharacterSet = nil;
   iCalEventChanges *changes;
   NSArray *changedProperties;
   NSCalendarDate *dateValue;
-  NSInteger offset;
 
   changes = [iCalEventChanges changesFromEvent: event toEvent: exceptionEvent];
 
@@ -1385,28 +1356,17 @@ static NSCharacterSet *hexCharacterSet = nil;
   memset (extendedException, 0, sizeof (struct ExtendedException));
   extendedException->ChangeHighlight.Size = sizeof (uint32_t);
 
-  dateValue = [exceptionEvent startDate];
-  offset = [timeZone secondsFromGMTForDate: dateValue];
-  dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                     hours: 0 minutes: 0
-                                   seconds: offset];
+  dateValue = [timeZone computedDateForDate: [exceptionEvent startDate]];
   exceptionInfo->StartDateTime = [dateValue asMinutesSince1601];
   extendedException->ChangeHighlight.Value = BIT_CH_START;
   extendedException->StartDateTime = exceptionInfo->StartDateTime;
 
-  dateValue = [exceptionEvent endDate];
-  offset = [timeZone secondsFromGMTForDate: dateValue];
-  dateValue = [dateValue dateByAddingYears: 0 months: 0 days: 0
-                                     hours: 0 minutes: 0
-                                   seconds: offset];
+  dateValue = [timeZone computedDateForDate: [exceptionEvent endDate]];
   exceptionInfo->EndDateTime = [dateValue asMinutesSince1601];
   extendedException->ChangeHighlight.Value |= BIT_CH_END;
   extendedException->EndDateTime = exceptionInfo->EndDateTime;
 
-  dateValue = [[exceptionEvent recurrenceId]
-                dateByAddingYears: 0 months: 0 days: 0
-                hours: 0 minutes: 0
-                seconds: offset];
+  dateValue = [timeZone computedDateForDate: [exceptionEvent recurrenceId]];
   exceptionInfo->OriginalStartDate = [dateValue asMinutesSince1601];
   extendedException->OriginalStartDate = exceptionInfo->OriginalStartDate;
 
@@ -1464,7 +1424,6 @@ static NSCharacterSet *hexCharacterSet = nil;
       arp = talloc_zero (NULL, struct AppointmentRecurrencePattern);
       [rule fillRecurrencePattern: &arp->RecurrencePattern
                         withEvent: event
-                       inTimeZone: timeZone
                          inMemCtx: arp];
       arp->ReaderVersion2 = 0x00003006;
       arp->WriterVersion2 = 0x00003008; /* 0x3008 for compatibility with
@@ -1475,7 +1434,7 @@ static NSCharacterSet *hexCharacterSet = nil;
 	 fields are relative to midnight of those days ([MS-OXOCAL] 2.2.1.44.5),
 	 so no time zone adjustment is needed */
       if (![event isAllDay])
-        [firstStartDate setTimeZone: timeZone];
+        firstStartDate = [timeZone computedDateForDate: firstStartDate];
       startMinutes = ([firstStartDate hourOfDay] * 60
                       + [firstStartDate minuteOfHour]);
       arp->StartTimeOffset = startMinutes;
@@ -1701,15 +1660,16 @@ ReservedBlockEE2Size: 00 00 00 00
                  fromDate: (NSCalendarDate *) instanceDate;
 {
   uint16_t year;
+  NSCalendarDate *dateValue;
 
   if (instanceDate)
     {
-      [instanceDate setTimeZone: timeZone];
-      year = [instanceDate yearOfCommonEra];
+      dateValue = [timeZone computedDateForDate: instanceDate];
+      year = [dateValue yearOfCommonEra];
       newGlobalId->YH = year >> 8;
       newGlobalId->YL = year & 0xff;
-      newGlobalId->Month = [instanceDate monthOfYear];
-      newGlobalId->D = [instanceDate dayOfMonth];
+      newGlobalId->Month = [dateValue monthOfYear];
+      newGlobalId->D = [dateValue dayOfMonth];
     }
 }
 
@@ -1974,7 +1934,6 @@ ReservedBlockEE2Size: 00 00 00 00
   if (alarm)
     {
       alarmDate = [alarm nextAlarmDate];
-      [alarmDate setTimeZone: utcTZ];
       *data = [alarmDate asFileTimeInMemCtx: memCtx];
     }
   else
@@ -2036,8 +1995,7 @@ ReservedBlockEE2Size: 00 00 00 00
   enum mapistore_error rc;
   NSString *tzid;
 
-  tzid = [(iCalDateTime *) [event firstChildWithTag: @"dtstart"]
-           value: 0 ofAttribute: @"tzid"];
+  tzid = [timeZone tzId];
   if ([tzid length] > 0)
     {
       *data = [tzid asUnicodeInMemCtx: memCtx];
@@ -2053,16 +2011,9 @@ ReservedBlockEE2Size: 00 00 00 00
                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
-  iCalTimeZone *icalTZ;
 
-  icalTZ = [(iCalDateTime *) [event firstChildWithTag: @"dtstart"] timeZone];
-  if (icalTZ)
-    {
-      *data = [icalTZ asTimeZoneStructInMemCtx: memCtx];
-      rc = MAPISTORE_SUCCESS;
-    }
-  else
-    rc = MAPISTORE_ERR_NOT_FOUND;
+  *data = [timeZone asTimeZoneStructInMemCtx: memCtx];
+  rc = MAPISTORE_SUCCESS;
 
   return rc;
 }
@@ -2071,24 +2022,16 @@ ReservedBlockEE2Size: 00 00 00 00
                                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
-  iCalTimeZone *icalTZ;
 
   /* [MS-OXOCAL] 3.1.5.5.1: This property is used in floating (all-day) events,
      specified in floating time, to convert the start date from UTC to the user's
      time zone */
-  if ([event isAllDay])
-    icalTZ = [iCalTimeZone timeZoneForName: [timeZone timeZoneName]];
-  else if ([event isRecurrent])
-    icalTZ = [(iCalDateTime *) [event firstChildWithTag: @"dtstart"] timeZone];
-  else
-    icalTZ = nil;
-
-  if (icalTZ)
+  if ([event isAllDay] | [event isRecurrent])
     {
       /* [MS-OXOCAL] 2.2.1.42: This property can only have the E flag set in the
          TimeZoneDefinition struct */
-      *data = [icalTZ asZoneTimeDefinitionWithFlags: TZRULE_FLAG_EFFECTIVE_TZREG
-                                           inMemCtx: memCtx];
+      *data = [timeZone asZoneTimeDefinitionWithFlags: TZRULE_FLAG_EFFECTIVE_TZREG
+                                             inMemCtx: memCtx];
       rc = MAPISTORE_SUCCESS;
     }
   else

--- a/OpenChange/MAPIStoreCalendarEmbeddedMessage.m
+++ b/OpenChange/MAPIStoreCalendarEmbeddedMessage.m
@@ -58,7 +58,6 @@
                 wrapperWithICalEvent: [newContainer event]
                              andUser: [userContext sogoUser]
                       andSenderEmail: nil
-                          inTimeZone: [userContext timeZone]
                   withConnectionInfo: [context connectionInfo]];
       [self addProxy: appointmentWrapper];
     }

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -197,7 +197,6 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
         = [MAPIStoreAppointmentWrapper wrapperWithICalEvent: masterEvent
                                                     andUser: [userContext sogoUser]
                                              andSenderEmail: nil
-                                                 inTimeZone: [userContext timeZone]
                                          withConnectionInfo: [context connectionInfo]];
       [self addProxy: appointmentWrapper];
     }

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -340,7 +340,6 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
                                  wrapperWithICalEvent: event
                                               andUser: [context activeUser]
                                        andSenderEmail: senderEmail
-                                           inTimeZone: [[self userContext] timeZone]
                                    withConnectionInfo: [context connectionInfo]];
           [appointmentWrapper retain];
         }

--- a/OpenChange/MAPIStoreRecurrenceUtils.h
+++ b/OpenChange/MAPIStoreRecurrenceUtils.h
@@ -29,6 +29,7 @@
 
 #import <NGCards/iCalCalendar.h>
 #import <NGCards/iCalRecurrenceRule.h>
+#import <NGCards/iCalTimeZone.h>
 
 @class NSTimeZone;
 
@@ -46,7 +47,7 @@
                    fromRecurrencePattern: (struct RecurrencePattern *) rp
                           withExceptions: (struct ExceptionInfo *) exInfos
                        andExceptionCount: (uint16_t) exInfoCount
-                              inTimeZone: (NSTimeZone *) tz;
+                              inTimeZone: (iCalTimeZone *) tz;
 
 @end
 

--- a/OpenChange/MAPIStoreRecurrenceUtils.h
+++ b/OpenChange/MAPIStoreRecurrenceUtils.h
@@ -25,13 +25,9 @@
 
 #include <talloc.h>
 
-#import <Foundation/NSTimeZone.h>
-
 #import <NGCards/iCalCalendar.h>
 #import <NGCards/iCalRecurrenceRule.h>
 #import <NGCards/iCalTimeZone.h>
-
-@class NSTimeZone;
 
 @class iCalEvent;
 @class iCalRepeatableEntityObject;
@@ -55,7 +51,6 @@
 
 - (void) fillRecurrencePattern: (struct RecurrencePattern *) rp
                      withEvent: (iCalEvent *) event
-                    inTimeZone: (NSTimeZone *) timeZone
                       inMemCtx: (TALLOC_CTX *) memCtx;
 
 @end

--- a/OpenChange/MAPIStoreRecurrenceUtils.m
+++ b/OpenChange/MAPIStoreRecurrenceUtils.m
@@ -24,7 +24,6 @@
 #import <Foundation/NSCalendarDate.h>
 #import <Foundation/NSSet.h>
 #import <Foundation/NSString.h>
-#import <Foundation/NSTimeZone.h>
 
 #import <NGExtensions/NSCalendarDate+misc.h>
 #import <NGExtensions/NSObject+Logs.h>
@@ -265,7 +264,6 @@
 
 - (void) fillRecurrencePattern: (struct RecurrencePattern *) rp
                      withEvent: (iCalEvent *) event
-                    inTimeZone: (NSTimeZone *) timeZone
                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   iCalRecurrenceFrequency freq;
@@ -281,10 +279,8 @@
   NSMutableArray *deletedDates, *modifiedDates;
 
   startDate = [event firstRecurrenceStartDate];
-  [startDate setTimeZone: timeZone];
   endDate = [event lastPossibleRecurrenceStartDate];
-  [endDate setTimeZone: timeZone];
-  
+
   rp->ReaderVersion = 0x3004;
   rp->WriterVersion = 0x3004;
 

--- a/OpenChange/MAPIStoreRecurrenceUtils.m
+++ b/OpenChange/MAPIStoreRecurrenceUtils.m
@@ -35,6 +35,7 @@
 #import <NGCards/iCalRepeatableEntityObject.h>
 #import <NGCards/iCalRecurrenceRule.h>
 #import <NGCards/iCalTimeZone.h>
+#import <NGCards/iCalTimeZonePeriod.h>
 
 #import "NSDate+MAPIStore.h"
 #import "MAPIStoreRecurrenceUtils.h"
@@ -51,7 +52,7 @@
                    fromRecurrencePattern: (struct RecurrencePattern *) rp
                           withExceptions: (struct ExceptionInfo *) exInfos
                        andExceptionCount: (uint16_t) exInfoCount
-                              inTimeZone: (NSTimeZone *) tz
+                              inTimeZone: (iCalTimeZone *) tz
 
 {
   NSCalendarDate *startDate, *olEndDate, *untilDate, *exDate;
@@ -63,7 +64,7 @@
   iCalWeekOccurrence weekOccurrence;
   iCalWeekOccurrences dayMaskDays;
   NSUInteger count, max;
-  NSInteger bySetPos;
+  NSInteger bySetPos, tzOffset;
   unsigned char maskValue;
 
   [entity removeAllRecurrenceRules];
@@ -242,9 +243,10 @@
           {
             /* The OriginalStartDate is in local time */
             exDate = [NSDate dateFromMinutesSince1601: exInfos[count].OriginalStartDate];
+            tzOffset = -[[tz periodForDate: exDate] secondsOffsetFromGMT];
             exDate = [exDate dateByAddingYears: 0 months: 0 days: 0
                                          hours: 0 minutes: 0
-                                       seconds: - [tz secondsFromGMT]];
+                                       seconds: tzOffset];
             [exceptionDates removeObject: exDate];
           }
       }

--- a/OpenChange/NSDate+MAPIStore.h
+++ b/OpenChange/NSDate+MAPIStore.h
@@ -37,6 +37,8 @@
 
 - (BOOL) isNever; /* occurs on 4500-12-31 */
 
++ (NSCalendarDate *) dateFromSystemTime: (struct SYSTEMTIME) date
+                            andRuleYear: (uint16_t) rYear;
 @end
 
 NSComparisonResult NSDateCompare (id date1, id date2, void *);

--- a/OpenChange/iCalTimeZone+MAPIStore.h
+++ b/OpenChange/iCalTimeZone+MAPIStore.h
@@ -33,6 +33,8 @@
 - (iCalTimeZone *) iCalTimeZoneFromDefinition: (NSData *) value
                               withDescription: (NSString *) description
                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (NSCalendarDate *) shiftedCalendarDateForDate: (NSCalendarDate *) date;
+
 
 @end
 

--- a/OpenChange/iCalTimeZone+MAPIStore.h
+++ b/OpenChange/iCalTimeZone+MAPIStore.h
@@ -30,6 +30,9 @@
 - (struct Binary_r *) asTimeZoneStructInMemCtx: (TALLOC_CTX *) memCtx;
 - (struct Binary_r *) asZoneTimeDefinitionWithFlags: (enum TZRuleFlag) flags
                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (iCalTimeZone *) iCalTimeZoneFromDefinition: (NSData *) value
+                              withDescription: (NSString *) description
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
 
 @end
 

--- a/OpenChange/iCalTimeZone+MAPIStore.m
+++ b/OpenChange/iCalTimeZone+MAPIStore.m
@@ -103,18 +103,18 @@
 {
   iCalTimeZonePeriod *period;
   struct TimeZoneStruct tz;
-  int lBias, dlBias;
+  int32_t lBias, dlBias;
 
   memset (&tz, 0, sizeof (struct TimeZoneStruct));
   period = [self _mostRecentPeriodWithName: @"STANDARD"];
   lBias = -[period secondsOffsetFromGMT] / 60;
-  tz.lBias = (uint32_t) lBias;
+  tz.lBias = lBias;
   [period _fillTZDate: &tz.stStandardDate];
   period = [self _mostRecentPeriodWithName: @"DAYLIGHT"];
   if (!period)
     tz.stStandardDate.wMonth = 0;
   dlBias = -([period secondsOffsetFromGMT] / 60) - lBias;
-  tz.lDaylightBias = (uint32_t) (dlBias);
+  tz.lDaylightBias = dlBias;
   [period _fillTZDate: &tz.stDaylightDate];
   tz.wStandardYear = tz.stStandardDate.wYear;
   tz.wDaylightYear = tz.stDaylightDate.wYear;
@@ -153,13 +153,13 @@
   period = [self _mostRecentPeriodWithName: @"STANDARD"];
   rule.wYear = [[period startDate] yearOfCommonEra];
   lBias = -[period secondsOffsetFromGMT] / 60;
-  rule.lBias = (uint32_t) lBias;
+  rule.lBias = lBias;
   [period _fillTZDate: &rule.stStandardDate];
   period = [self _mostRecentPeriodWithName: @"DAYLIGHT"];
   if (!period)
     rule.stStandardDate.wMonth = 0;
   dlBias = -([period secondsOffsetFromGMT] / 60) - lBias;
-  rule.lDaylightBias = (uint32_t) (dlBias);
+  rule.lDaylightBias = dlBias;
   [period _fillTZDate: &rule.stDaylightDate];
 
 

--- a/OpenChange/iCalTimeZone+MAPIStore.m
+++ b/OpenChange/iCalTimeZone+MAPIStore.m
@@ -23,11 +23,15 @@
 #import <Foundation/NSArray.h>
 #import <Foundation/NSCalendarDate.h>
 #import <Foundation/NSString.h>
+#import <Foundation/NSTimeZone.h>
 #import <NGCards/iCalByDayMask.h>
+#import <NGCards/iCalDateTime.h>
 #import <NGCards/iCalTimeZonePeriod.h>
 #import <NGCards/iCalRecurrenceRule.h>
 
 #import "NSString+MAPIStore.h"
+#import "NSData+MAPIStore.h"
+#import "NSDate+MAPIStore.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -166,5 +170,186 @@
   return set_TimeZoneDefinition (memCtx, &definition);
 }
 
+- (NSString *) _offsetStringFromOffset: (NSInteger) offset
+{
+  NSInteger offsetHours, offsetMins;
+  NSString *offsetSign;
+
+  /* The offset format is, eg, "+0200" for 2 hours 0 minutes ahead */
+  if (offset < 0)
+    offsetSign = @"-";
+  else
+    offsetSign = @"+";
+  offsetHours = abs (offset) / 60;
+  offsetMins = abs (offset) % 60;
+
+  return [NSString stringWithFormat:  @"%@%d%d%d%d",
+           offsetSign, offsetHours / 10, offsetHours % 10,
+           offsetMins / 10, offsetMins % 10];
+
+}
+
+- (NSString *) _rRuleStringFromSystemTime: (struct SYSTEMTIME) date
+{
+  NSString *result, *byDay;
+
+  /* The conversion tables between the SYSTEMTIME fields and the RRULE ones
+     can be found at [MS-OXCICAL] 2.1.3.2.1 */
+  if (date.wDay == 5)
+    byDay = @"-1";
+  else
+    byDay = [NSString stringWithFormat: @"%d", date.wDay];
+
+  switch (date.wDayOfWeek)
+    {
+    case iCalWeekDaySunday:
+      byDay = [byDay stringByAppendingString: @"SU"];
+      break;
+    case iCalWeekDayMonday:
+      byDay = [byDay stringByAppendingString: @"MO"];
+      break;
+    case iCalWeekDayTuesday:
+      byDay = [byDay stringByAppendingString: @"TU"];
+      break;
+    case iCalWeekDayWednesday:
+      byDay = [byDay stringByAppendingString: @"WE"];
+      break;
+    case iCalWeekDayThursday:
+      byDay = [byDay stringByAppendingString: @"TH"];
+      break;
+    case iCalWeekDayFriday:
+      byDay = [byDay stringByAppendingString: @"FR"];
+      break;
+    case iCalWeekDaySaturday:
+      byDay = [byDay stringByAppendingString: @"SA"];
+      break;
+    }
+
+  result = [NSString stringWithFormat: @"FREQ=YEARLY;BYDAY=%@;BYMONTH=%d", byDay, date.wMonth];
+
+  return result;
+}
+
+- (iCalTimeZone *) iCalTimeZoneFromDefinition: (NSData *) value
+                              withDescription: (NSString *) description
+                                     inMemCtx: (TALLOC_CTX *) memCtx
+{
+  BOOL daylightDefined = NO, ruleFound = NO;
+  iCalDateTime *daylightStart, *standardStart;
+  iCalRecurrenceRule *daylightRRule, *standardRRule;
+  iCalTimeZone *tz = nil;
+  iCalTimeZonePeriod *daylight, *standard;
+  NSCalendarDate *dlStartValue, *stStartValue;
+  NSString *strOffsetFrom, *strOffsetTo, *tzID;
+  char *keyName;
+  struct Binary_r *binValue;
+  struct SYSTEMTIME initDate;
+  struct TimeZoneDefinition *definition;
+  struct TZRule rule;
+  uint16_t count;
+
+  binValue = [value asBinaryInMemCtx: memCtx];
+  definition = get_TimeZoneDefinition (memCtx, binValue);
+
+  if (!definition)
+    return nil;
+
+  if (!definition->cRules)
+    goto end;
+
+  for (count = 0; count < definition->cRules; count++)
+    {
+      /* ([MS-OXCICAL] 2.1.3.1.1.19) The TZRule with the
+         TZRULE_FLAG_EFFECTIVE_TZREG bit set in the TZRule flags field
+         is the one that MUST be exported */
+      if (definition->TZRules[count].flags & TZRULE_FLAG_EFFECTIVE_TZREG)
+        {
+          rule = definition->TZRules[count];
+          ruleFound = YES;
+          break;
+        }
+    }
+
+  if (!ruleFound)
+    goto end;
+
+  if (!description)
+    {
+      /* The cbHeader field contains the size, in bytes of the Reserved (2b),
+         cchKeyName (2b) keyName (variable Unicode string) and cRules (2b)
+         ([MS-OXOCAL] 2.2.1.41). The keyName field is a non-NULL-terminated
+         char array. */
+      keyName = talloc_strndup (memCtx, definition->keyName, (definition->cbHeader - 6) / 2);
+      tzID = [NSString stringWithCString: keyName
+                                encoding: [NSString defaultCStringEncoding]];
+      talloc_free (keyName);
+    }
+  else
+    tzID = [NSString stringWithString: description];
+
+  tz = [iCalTimeZone groupWithTag: @"vtimezone"];
+  [tz addChild: [CardElement simpleElementWithTag: @"tzid"
+                                            value: tzID]];
+
+  if (rule.stStandardDate.wMonth != 0)
+    daylightDefined = YES;
+
+  /* STANDARD TIME ([MS-OXCICAL] 2.1.3.1.1.19.2) */
+  standard = [iCalTimeZonePeriod groupWithTag: @"standard"];
+
+  /* TZOFFSETFROM = -1 * (PidLidTimeZoneStruct.lBias + PidLidTimeZoneStruct.lDaylightBias) */
+  strOffsetFrom = [self _offsetStringFromOffset: -1 * (rule.lBias + rule.lDaylightBias)];
+  [standard addChild: [CardElement simpleElementWithTag: @"tzoffsetfrom"
+                                                  value: strOffsetFrom]];
+
+  /* TZOFFSETTO = -1 * (PidLidTimeZoneStruct.lBias + PidLidTimeZoneStruct.lStandardBias) */
+  strOffsetTo = [self _offsetStringFromOffset: -1 * (rule.lBias + rule.lStandardBias)];
+  [standard addChild: [CardElement simpleElementWithTag: @"tzoffsetto"
+                                                  value: strOffsetTo]];
+
+  /* DTSTART & RRULE are derived from the stStandardDate and wYear properties */
+  standardStart = [iCalDateTime elementWithTag: @"dtstart"];
+
+  initDate = rule.stStandardDate;
+  stStartValue = [NSCalendarDate dateFromSystemTime: initDate
+                                        andRuleYear: rule.wYear];
+
+  [standardStart setDateTime: stStartValue];
+  [standard addChild: standardStart];
+
+  if (daylightDefined)
+    {
+      standardRRule = [[iCalRecurrenceRule alloc] initWithString: [self _rRuleStringFromSystemTime: initDate]];
+      [standard addChild: standardRRule];
+
+      /* DAYLIGHT SAVING TIME ([MS-OXCICAL] 2.1.3.1.1.19.3) */
+      daylight = [iCalTimeZonePeriod groupWithTag: @"daylight"];
+      /* TZOFFSETFROM = -1 * (PidLidTimeZoneStruct.lBias + PidLidTimeZoneStruct.lStandardBias) */
+      [daylight addChild: [CardElement simpleElementWithTag: @"tzoffsetfrom"
+                                                      value: strOffsetTo]];
+      /* TZOFFSETTO = -1 * (PidLidTimeZoneStruct.lBias + PidLidTimeZoneStruct.lDaylightBias) */
+      [daylight addChild: [CardElement simpleElementWithTag: @"tzoffsetto"
+                                                      value: strOffsetFrom]];
+
+      /* DTSTART & RRULE are derived from the stDaylightDate and wYear properties */
+      daylightStart = [iCalDateTime elementWithTag: @"dtstart"];
+      initDate = rule.stDaylightDate;
+      dlStartValue = [NSCalendarDate dateFromSystemTime: initDate
+                                            andRuleYear: rule.wYear];
+
+      [daylightStart setDateTime: dlStartValue];
+      [daylight addChild: daylightStart];
+
+      daylightRRule = [[iCalRecurrenceRule alloc] initWithString: [self _rRuleStringFromSystemTime: initDate]];
+      [daylight addChild: daylightRRule];
+      [tz addChild: daylight];
+    }
+  [tz addChild: standard];
+
+end:
+
+  talloc_free (definition);
+  return tz;
+}
 
 @end

--- a/OpenChange/iCalTimeZone+MAPIStore.m
+++ b/OpenChange/iCalTimeZone+MAPIStore.m
@@ -40,6 +40,7 @@
 #include <libmapi/libmapi.h>
 
 #import "iCalTimeZone+MAPIStore.h"
+#import "MAPIStoreTypes.h"
 
 @interface iCalTimeZonePeriod (MAPIStorePropertiesPrivate)
 
@@ -350,6 +351,27 @@ end:
 
   talloc_free (definition);
   return tz;
+}
+
+/**
+ * Adjust a date in this vTimeZone to its representation in UTC
+ * Example: Timezone is +0001, the date is 2015-12-15 00:00:00 +0000
+ *                              it returns 2015-12-14 23:00:00 +0000
+ * @param date the date to adjust to the timezone.
+ * @return a new GMT date adjusted with the offset of the timezone.
+ */
+- (NSCalendarDate *) shiftedCalendarDateForDate: (NSCalendarDate *) date
+{
+  NSCalendarDate *tmpDate;
+
+  tmpDate = [date copy];
+  [tmpDate autorelease];
+
+  [tmpDate setTimeZone: utcTZ];
+
+  return [tmpDate addYear: 0 month: 0 day: 0
+                     hour: 0 minute: 0
+                   second: -[[self periodForDate: tmpDate] secondsOffsetFromGMT]];
 }
 
 @end


### PR DESCRIPTION
We were using the user time zone (the one in the webmail) by default, which caused shifts in the events when and the client one was different. This PR interprets the `TimeZoneDefinition` properties provided by the client and uses them to create and retrieve events.

* Suggested NEWS line:
`Fix shifts in event times`