### PR TITLE
oc-mail: Return error when delivery was not successful

### DIFF
--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -1053,6 +1053,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
 
 - (int) submitWithFlags: (enum SubmitFlags) flags
 {
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSDictionary *recipients;
   NSData *messageData;
   NSMutableArray *recipientEmails;
@@ -1099,7 +1100,10 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
                   withAuthenticator: authenticator
                           inContext: woContext];
       if (error)
-        [self logWithFormat: @"an error occurred: '%@'", error];
+        {
+          [self errorWithFormat: @"an error occurred: '%@'", error];
+          rc = MAPISTORE_ERR_MSG_SEND;
+        }
 
       // mapping = [self mapping];
       // [mapping unregisterURLWithID: [self objectId]];
@@ -1111,7 +1115,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
     [self logWithFormat: @"skipping submit of message with class '%@'",
           msgClass];
 
-  return MAPISTORE_SUCCESS;
+  return rc;
 }
 
 - (void) save: (TALLOC_CTX *) memCtx


### PR DESCRIPTION
For example, if the SMTP is down, then the message is not sent and
an error is returned. We returned back this error code to be managed
by upper layer.

`NEWS` tip in *Fixes* section:
* Return an error if mail message delivery fails