### PR TITLE
oc: Set Editor as role is now possible in Outlook

### DIFF
--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -117,11 +117,11 @@
   if ([roles containsObject: SOGoRole_ObjectCreator])
     rights |= RightsCreateItems;
   if ([roles containsObject: SOGoRole_ObjectEraser])
-    rights |= RightsDeleteAll;
+    rights |= RightsDeleteAll | RightsDeleteOwn;
   if ([roles containsObject: SOGoCalendarRole_PublicModifier]
       && [roles containsObject: SOGoCalendarRole_PrivateModifier]
       && [roles containsObject: SOGoCalendarRole_ConfidentialModifier])
-    rights |= RightsReadItems | RightsEditAll;
+    rights |= RightsReadItems | RightsEditAll | RightsEditOwn;
   else if ([roles containsObject: SOGoCalendarRole_PublicViewer]
            && [roles containsObject: SOGoCalendarRole_PrivateViewer]
            && [roles containsObject: SOGoCalendarRole_ConfidentialViewer])

--- a/OpenChange/MAPIStoreContactsFolder.m
+++ b/OpenChange/MAPIStoreContactsFolder.m
@@ -96,9 +96,9 @@
   if ([roles containsObject: SOGoRole_ObjectCreator])
     rights |= RightsCreateItems;
   if ([roles containsObject: SOGoRole_ObjectEraser])
-    rights |= RightsDeleteAll;
+    rights |= RightsDeleteAll | RightsDeleteOwn;
   if ([roles containsObject: SOGoRole_ObjectEditor])
-    rights |= RightsEditAll;
+    rights |= RightsEditAll | RightsEditOwn;
   if ([roles containsObject: SOGoRole_ObjectViewer])
     rights |= RightsReadItems;
   if (rights != 0)

--- a/OpenChange/MAPIStoreDBFolder.m
+++ b/OpenChange/MAPIStoreDBFolder.m
@@ -321,9 +321,9 @@ static NSString *MAPIStoreRightFolderContact = @"RightsFolderContact";
   if ([roles containsObject: MAPIStoreRightDeleteOwn])
     rights |= RightsDeleteOwn;
   if ([roles containsObject: MAPIStoreRightEditAll])
-    rights |= RightsEditAll;
+    rights |= RightsEditAll | RightsEditOwn;
   if ([roles containsObject: MAPIStoreRightDeleteAll])
-    rights |= RightsDeleteAll;
+    rights |= RightsDeleteAll | RightsDeleteOwn;
   if ([roles containsObject: MAPIStoreRightCreateSubfolders])
     rights |= RightsCreateSubfolders;
   if ([roles containsObject: MAPIStoreRightFolderOwner])

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -1711,10 +1711,10 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
     rights |= RightsCreateItems;
   if ([roles containsObject: SOGoRole_ObjectEraser]
       && [roles containsObject: SOGoRole_FolderEraser])
-    rights |= RightsDeleteAll;
+    rights |= RightsDeleteAll | RightsDeleteOwn;
 
   if ([roles containsObject: SOGoRole_ObjectEditor])
-    rights |= RightsEditAll;
+    rights |= RightsEditAll | RightsEditOwn;
   if ([roles containsObject: SOGoRole_ObjectViewer])
     rights |= RightsReadItems;
   if ([roles containsObject: SOGoRole_FolderCreator])

--- a/OpenChange/MAPIStoreTasksFolder.m
+++ b/OpenChange/MAPIStoreTasksFolder.m
@@ -107,11 +107,11 @@
   if ([roles containsObject: SOGoRole_ObjectCreator])
     rights |= RightsCreateItems;
   if ([roles containsObject: SOGoRole_ObjectEraser])
-    rights |= RightsDeleteAll;
+    rights |= RightsDeleteAll | RightsDeleteOwn;
   if ([roles containsObject: SOGoCalendarRole_PublicModifier]
       && [roles containsObject: SOGoCalendarRole_PrivateModifier]
       && [roles containsObject: SOGoCalendarRole_ConfidentialModifier])
-    rights |= RightsReadItems | RightsEditAll;
+    rights |= RightsReadItems | RightsEditAll | RightsEditOwn;
   else if ([roles containsObject: SOGoCalendarRole_PublicViewer]
            && [roles containsObject: SOGoCalendarRole_PrivateViewer]
            && [roles containsObject: SOGoCalendarRole_ConfidentialViewer])


### PR DESCRIPTION
According to [MS-OXCPERM] Section 2.2.7 in PidTagMemberRights possible
values, once we set the DeleteAny flag, the DeleteOwned flag must be set.
Likewise EditOwned must be set when EditAny is set. In this way,
the rights sent by the MAPI client are equal to the returned by the
server when Editor is set.

In real world practice, makes more strict Outlook 2013 work with editor permissions
the sharing of user's defined calendars, tasks or contacts folders as
the recipients can be editors of that folder.

`NEWS` tip in `Fixes` section:
Share calendar, tasks and contacts folders in Outlook 2013 with editor permissions