### PR TITLE
Calendar folder permission roles

### DIFF
--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -77,6 +77,17 @@
 
 - (NSArray *) rolesForExchangeRights: (uint32_t) rights
 {
+  /* Limitations
+
+     Following rights are not supported by SOGo specifically:
+
+     - DeleteOwned : Delete only own objects
+     - EditOwned : Edit only own objects
+     - CreateSubfolders: No calendar subfolders
+     - FolderOwner: No sharing folder ownership?
+     - FolderContact: No support to store this information
+     - FolderVisible: It is inferred by other rights when extracting
+   */
   NSMutableArray *roles;
 
   roles = [NSMutableArray arrayWithCapacity: 6];

--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -135,7 +135,7 @@
   if ([roles containsObject: SOGoCalendarRole_ConfidentialDAndTViewer])
       rights |= RightsFreeBusyDetailed;
 
-  if (rights != 0)
+  if ((rights & RightsReadItems) != 0 || (rights & RightsCreateItems) != 0 || (rights & RightsDeleteAll) != 0)
     rights |= RoleNone; /* actually "folder visible" */
 
   // [self logWithFormat: @"rights for roles (%@) = %.8x", roles, rights];

--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -121,7 +121,7 @@
   if ([roles containsObject: SOGoCalendarRole_PublicModifier]
       && [roles containsObject: SOGoCalendarRole_PrivateModifier]
       && [roles containsObject: SOGoCalendarRole_ConfidentialModifier])
-    rights |= RightsReadItems | RightsEditAll | RightsEditOwn;
+    rights |= RightsReadItems | RightsEditAll | RightsEditOwn | RightsFreeBusySimple | RightsFreeBusyDetailed;
   else if ([roles containsObject: SOGoCalendarRole_PublicViewer]
            && [roles containsObject: SOGoCalendarRole_PrivateViewer]
            && [roles containsObject: SOGoCalendarRole_ConfidentialViewer])


### PR DESCRIPTION
Review and fixing all possible permission levels that could be assigned in a calendar folder:

* Editor role has been added
* Simple and Detailed Free/Busy permission level added

We have detailed in the code which permission flags are available in MAPI but it cannot be set in SOGo because the former are much more fine grained:

* DeleteOwned : Delete only own objects
* EditOwned : Edit only own objects
* CreateSubfolders: No calendar subfolders
* FolderOwner: No sharing folder ownership?
* FolderContact: No support to store this information
* FolderVisible: It is inferred by other rights when extracting

Tips for `NEWS` in `Enhancements` section:
* Editor role, Simple and Detailed Free/Busy permission level can be set in calendar folder permissions from Outlook.