### PR TITLE
Show contacts without email switching to Personal Address Book

### DIFF
--- a/SoObjects/Contacts/SOGoContactGCSFolder.m
+++ b/SoObjects/Contacts/SOGoContactGCSFolder.m
@@ -180,6 +180,9 @@ static NSArray *folderListingFields = nil;
     {
       filter = [[filter stringByReplacingString: @"\\"  withString: @"\\\\"]
                      stringByReplacingString: @"'"  withString: @"\\'\\'"];
+      if ([filter isEqualToString: @"."])
+        filter = @"_";  /* matches one “_” character and it uses by UI. */
+
       if ([criteria isEqualToString: @"name_or_address"])
         qs = [NSString stringWithFormat:
                          @"(c_sn isCaseInsensitiveLike: '%%%@%%') OR "


### PR DESCRIPTION
After applying patch 1c8b69365, the UI is asking for all contacts
with a "." when switching back to Personal Address Book after
going to other contact list. As the any character placeholder
for SQL is '_' and unlike LDAP which is '.' we have to perform this
replacement.

`NEWS` tip:
* Show contacts without email when switching to Personal Address Book in WebMail