### PR TITLE
oc-calendar: Handle appointment notifications more accurately

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.h
+++ b/OpenChange/MAPIStoreAppointmentWrapper.h
@@ -119,7 +119,7 @@
                            inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidLidBusyStatus: (void **) data // TODO
                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidIndentedBusyStatus: (void **) data // TODO
+- (int) getPidLidIntendedBusyStatus: (void **) data
                            inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidTagNormalizedSubject: (void **) data // SUMMARY
                           inMemCtx: (TALLOC_CTX *) memCtx;
@@ -149,6 +149,8 @@
                                 inMemCtx: (TALLOC_CTX *) memCtx;
 - (int) getPidLidAppointmentReplyTime: (void **) data
                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (int) getPidLidClientIntent: (void **) data
+                     inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* reminders */
 - (int) getPidLidReminderSet: (void **) data

--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -552,9 +552,7 @@ static NSCharacterSet *hexCharacterSet = nil;
 - (int) getPidLidMeetingType: (void **) data
                     inMemCtx: (TALLOC_CTX *) memCtx
 {
-  /* TODO
-     See 2.2.6.5 PidLidMeetingType (OXOCAL) */
-  *data = MAPILongValue (memCtx, 0x00000001);
+  *data = MAPILongValue (memCtx, mtgEmpty);
 
   return MAPISTORE_SUCCESS;
 }

--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -123,7 +123,13 @@ static NSCharacterSet *hexCharacterSet = nil;
 
   attendee = [event userAsAttendee: user];
   if (attendee)
-    method = @"REQUEST";
+    {
+      if ([[attendee partStat] isEqualToString: @"NEEDS-ACTION"])
+        method = @"REQUEST";
+      else
+        method = @"REPLY";
+      partstat = [attendee participationStatus];
+    }
   else if ([event userIsOrganizer: user])
     {
       if (senderEmail)
@@ -478,7 +484,7 @@ static NSCharacterSet *hexCharacterSet = nil;
     [self _setupITIPContext];
 
   longValue = 0x0400;
-  
+
   if (method)
     {
       if ([method isEqualToString: @"REQUEST"])
@@ -512,7 +518,7 @@ static NSCharacterSet *hexCharacterSet = nil;
       if ([[event attendees] count] > 0)
         longValue |= 0x0002;
     }
-  
+
   *data = MAPILongValue (memCtx, longValue);
 
   return MAPISTORE_SUCCESS;
@@ -645,6 +651,9 @@ static NSCharacterSet *hexCharacterSet = nil;
 - (int) getPidLidAppointmentMessageClass: (void **) data
                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
+  if (!method)
+    return MAPISTORE_ERR_NOT_FOUND;
+
   *data = talloc_strdup (memCtx, "IPM.Appointment");
 
   return MAPISTORE_SUCCESS;
@@ -1114,7 +1123,7 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidIndentedBusyStatus: (void **) data // TODO
+- (int) getPidLidIntendedBusyStatus: (void **) data
                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidBusyStatus: data inMemCtx: memCtx];
@@ -1826,6 +1835,43 @@ ReservedBlockEE2Size: 00 00 00 00
     }
 
   return rc;
+}
+
+
+- (int) getPidLidClientIntent: (void **) data
+                     inMemCtx: (TALLOC_CTX *) memCtx
+{
+  uint32_t longValue;
+
+  if (!itipSetup)
+    [self _setupITIPContext];
+
+  longValue = 0x0000;
+
+  if ([event userIsOrganizer: user])
+    longValue |= CI_MANAGER;
+
+  if (method)
+    {
+      switch (partstat)
+      {
+      case iCalPersonPartStatTentative:
+        longValue |= CI_RESP_TENTATIVE;
+        break;
+      case iCalPersonPartStatAccepted:
+        longValue |= CI_RESP_ACCEPT;
+        break;
+      case iCalPersonPartStatDeclined:
+        longValue |= CI_RESP_DECLINE;
+        break;
+      default:
+        break;
+      }
+    }
+
+  *data = MAPILongValue (memCtx, longValue);
+
+  return MAPISTORE_SUCCESS;
 }
 
 /* reminders */

--- a/OpenChange/MAPIStoreCalendarMessage.h
+++ b/OpenChange/MAPIStoreCalendarMessage.h
@@ -35,6 +35,8 @@
   iCalEvent *masterEvent;
 }
 
+- (BOOL) isUpdateRequest;
+
 @end
 
 #endif /* MAPISTORECALENDARMESSAGE_H */

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -652,4 +652,16 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return MAPISTORE_SUCCESS;
 }
 
+- (BOOL) isUpdateRequest
+{
+  iCalPerson *ownerAttendee;
+  SOGoUser *owner;
+
+  owner = [[self userContext] sogoUser];
+  ownerAttendee = [masterEvent userAsAttendee: owner];
+
+  return (ownerAttendee && [[ownerAttendee partStat] isEqualToString: @"NEEDS-ACTION"]
+          && ([masterEvent sequence] > 0));
+}
+
 @end

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -451,6 +451,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   WOContext *woContext;
   SOGoAppointmentFolder *folder;
   SOGoAppointmentObject *newObject;
+  bool softDeleted;
 
   cname = [[container sogoObject] resourceNameForEventUID: uid];
   if (cname)
@@ -478,14 +479,14 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
         }
     }
   else
-    {
-      /* dissociate the object url from the old object's id */
-      objectId = [mapping idFromURL: url];
-      [mapping unregisterURLWithID: objectId];
-      newObject = [folder lookupName: cname
-                           inContext: woContext
-                             acquire: NO];
-    }
+    newObject = [folder lookupName: cname
+                         inContext: woContext
+                           acquire: NO];
+
+  /* dissociate the object url from the old object's id */
+  objectId = [mapping idFromURL: url isSoftDeleted: &softDeleted];
+  if (objectId != NSNotFound)
+    [mapping unregisterURLWithID: objectId];
 
   /* dissociate the object url associated with this object, as we want to
      discard it */

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -231,10 +231,13 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
 - (int) getPidTagMessageClass: (void **) data
                      inMemCtx: (TALLOC_CTX *) memCtx
 {
+  iCalPerson *ownerAttendee;
   SOGoUser *owner;
 
   owner = [[self userContext] sogoUser];
-  if ([masterEvent userAsAttendee: owner])
+  ownerAttendee = [masterEvent userAsAttendee: owner];
+
+  if (ownerAttendee && [[ownerAttendee partStat] isEqualToString: @"NEEDS-ACTION"])
     *data = talloc_strdup (memCtx, "IPM.Schedule.Meeting.Request");
   else
     *data = talloc_strdup (memCtx, "IPM.Appointment");

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -496,6 +496,9 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
 - (int) getPidLidResponseStatus: (void **) data
                        inMemCtx: (TALLOC_CTX *) memCtx
 {
+  if (mailIsEvent)
+    return [[self _appointmentWrapper] getPidLidResponseStatus: data inMemCtx: memCtx];
+
   *data = MAPILongValue (memCtx, 0);
 
   return MAPISTORE_SUCCESS;

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -1258,6 +1258,17 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
+- (int) getPidLidAppointmentSequence: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
+{
+  if (!headerSetup)
+    [self _fetchHeaderData];
+
+  return (mailIsEvent
+          ? [[self _appointmentWrapper] getPidLidAppointmentSequence: data inMemCtx: memCtx]
+          : MAPISTORE_ERR_NOT_FOUND);
+}
+
 - (int) getPidLidAppointmentStartWhole: (void **) data
                               inMemCtx: (TALLOC_CTX *) memCtx
 {

--- a/OpenChange/NSData+MAPIStore.h
+++ b/OpenChange/NSData+MAPIStore.h
@@ -49,6 +49,8 @@
 
 - (void) hexDumpWithLineSize: (NSUInteger) lineSize;
 
+- (NSString *) globalObjectIdToUid: (void *) memCtx;
+
 @end
 
 @interface NSMutableData (MAPIStoreDataTypes)

--- a/OpenChange/NSData+MAPIStore.m
+++ b/OpenChange/NSData+MAPIStore.m
@@ -251,6 +251,34 @@ static void _fillFlatUIDWithGUID (struct FlatUID_r *flatUID, const struct GUID *
     }
 }
 
+- (NSString *) globalObjectIdToUid: (void *) memCtx
+{
+  NSString *uid = nil;
+  char *bytesDup, *uidStart;
+  NSUInteger length;
+
+  /* NOTE: we only handle the generic case at the moment, see
+     MAPIStoreAppointmentWrapper */
+  length = [self length];
+  bytesDup = talloc_array (memCtx, char, length + 1);
+  if (!bytesDup)
+    {
+      NSLog (@"%s: Out of memory");
+      return nil;
+    }
+  memcpy (bytesDup, [self bytes], length);
+
+  bytesDup[length] = 0;
+  uidStart = bytesDup + length - 1;
+  while (uidStart != bytesDup && *(uidStart - 1))
+    uidStart--;
+  if (uidStart > bytesDup && *uidStart)
+    uid = [NSString stringWithUTF8String: uidStart];
+
+  talloc_free (bytesDup);
+  return uid;
+}
+
 @end
 
 @implementation NSMutableData (MAPIStoreDataTypes)


### PR DESCRIPTION
This PR needs https://github.com/zentyal/openchange/pull/204 & https://github.com/zentyal/openchange/pull/205.

Several fixes in the calendar code:
- By returning the correct _PidLidMeetingType_, event update notification mails show the diff between the old version of the appointment and the new one.
- A declination mail was being sent when we accepted an update because the client deletes the old version of the appointment and stores the new one, and the SOGo code that prepares the deletion sends that mail. Now, we detect when we're responding to an update and skip the deletion preparation.
- Additionally, we prepare this deletion when the client sends the cancellation mail (this submission was being ignored by SOGo/OC), so if we're declining an update the mail is actually sent. We also handle here the case when we decline the first invitation, deleting the SOGo object. Outlook didn't do this because it doesn't care about appointments until we first accept them.
- A bunch of properties are returned more accurately, although this doesn't have an impact on the behaviour of the client.

Suggested `NEWS` line:
- Fix sending of declination mails when accepting an event update
- Display diff between event versions when receiving an event update notification
