### PR TITLE
Allow exception raising when connecting to IMAP

### DIFF
--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -172,6 +172,11 @@ sogo_backend_init (void)
 
   /* We force the plugin to base its configuration on the SOGo tree. */
   ud = [NSUserDefaults standardUserDefaults];
+
+  /* Ensure imap4Connection calls raise Exception if
+    IMAP connection is not established. See NGImap4Connection.m */
+  [ud setBool: YES forKey: @"SoIMAP4ExceptionsEnabled"];
+
   if (!leakDebugging && [ud boolForKey: @"SOGoDebugLeaks"])
     {
       NSLog (@"  leak debugging on");

--- a/SoObjects/Mailer/SOGoMailBaseObject.h
+++ b/SoObjects/Mailer/SOGoMailBaseObject.h
@@ -46,9 +46,12 @@
 {
   NSURL             *imap4URL;
   NGImap4Connection *imap4;
+  BOOL              imap4ExceptionsEnabled;
 }
 
 - (BOOL) isFolderish;
+
+- (id) init;
 
 - (id) initWithImap4URL: (NSURL *) _url
 	    inContainer: (id) _container;

--- a/SoObjects/Mailer/SOGoMailBaseObject.m
+++ b/SoObjects/Mailer/SOGoMailBaseObject.m
@@ -45,11 +45,25 @@
 
 @implementation SOGoMailBaseObject
 
+
+- (id)init
+{
+  if ((self = [super init]))
+    {
+      NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+      // With this to YES, imap4Connection will raise exception if a working
+      // connection cannot be provided
+      imap4ExceptionsEnabled = [ud boolForKey:@"SoIMAP4ExceptionsEnabled"];
+    }
+
+  return self;
+}
+
 - (id) initWithImap4URL: (NSURL *) _url
 	    inContainer: (id) _container
 {
   NSString *n;
-  
+
   n = [[_url path] lastPathComponent];
   if ((self = [self initWithName: n inContainer:_container]))
     {
@@ -148,7 +162,10 @@
   if (!newConnection)
     {
       newConnection = (NGImap4Connection *) [NSNull null];
-      [self errorWithFormat:@"Could not connect IMAP4"];
+      if (imap4ExceptionsEnabled)
+        [NSException raise: @"IOException" format: @"IMAP connection failed"];
+      else
+        [self errorWithFormat:@"Could not connect IMAP4"];
     }
   else
     {
@@ -205,6 +222,22 @@
         }
       [imap4 retain];
     }
+
+   // Connection broken, try to reconnect
+   if (![imap4 isKindOfClass: [NSNull class]] && ![[[imap4 client] isConnected] boolValue])
+     {
+       [self warnWithFormat: @"IMAP connection is broken, trying to reconnect..."];
+       [[imap4 client] reconnect];
+
+       // Still broken, give up
+       if (![[[imap4 client] isConnected] boolValue])
+         {
+           if (imap4ExceptionsEnabled)
+             [NSException raise: @"IOException" format: @"IMAP connection failed"];
+           else
+             [self errorWithFormat: @"Could not get a valid IMAP connection"];
+         }
+     }
 
   return [imap4 isKindOfClass: [NSNull class]] ? nil : imap4;
 }


### PR DESCRIPTION
By setting `SoIMAP4ExceptionsEnabled` config key to YES

Enabled for OpenChange by default, it will ensure no action is taken
when IMAP connection is not valid.

It would be desirable to release this change after https://github.com/zentyal/sope/pull/26 is released, as reconnect will cause too many open descriptors without that fix applied