### PR TITLE
oc-mail: Replace end of line in text parts of mixed messages

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -400,10 +400,14 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
             {
               NSMutableData *target;
               NSString *charset;
+              BOOL replaceEOL = NO;
               if ([mimeType isEqualToString: @"text/html"])
                 target = htmlContent;
               else if ([mimeType isEqualToString: @"text/plain"])
-                target = textContent;
+                {
+                  target = textContent;
+                  replaceEOL = multipartMixed;
+                }
               else
                 {
                   [self warnWithFormat: @"Unsupported MIME type for non-event body part: %@.",
@@ -416,6 +420,9 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
               if (charset)
                 {
                   NSString *stringValue = [content bodyStringFromCharset: charset];
+                  if (replaceEOL)
+                    stringValue = [stringValue stringByReplacingOccurrencesOfString: @"\n"
+                                                                         withString: @"<br/>"];
                   [target appendData: [stringValue dataUsingEncoding: NSUTF8StringEncoding]];
                 }
               else


### PR DESCRIPTION
In multipart/mixed messages we return all in the PidTagHtml
property, however due to the HTML rendering end of lines are
ignored. To avoid this we replace EOL with the <br/> tag

This is branched from #245 . I will take care of changes after that merge.

Suggested NEWS: text part in multipart/mixed are better rendered