### PR TITLE
oc-mail: Better management of nested multipart types

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -44,11 +44,11 @@
   NSMutableDictionary *bodyPartsEncodings;
   NSMutableDictionary *bodyPartsCharsets;
   NSMutableDictionary *bodyPartsMimeTypes;
+  NSMutableDictionary *bodyPartsMixed;
   
   NSString *headerCharset;
   NSString *headerMimeType;
   BOOL bodySetup;
-  BOOL multipartMixed;
   NSArray *bodyContent;
   BOOL fetchedAttachments;
 

--- a/SoObjects/Mailer/SOGoMailObject.h
+++ b/SoObjects/Mailer/SOGoMailObject.h
@@ -129,9 +129,9 @@ NSArray *SOGoMailCoreInfoKeys;
                           inContext: (id)_ctx;
 
 - (void) addRequiredKeysOfStructure: (NSDictionary *) info
-			       path: (NSString *) p
-			    toArray: (NSMutableArray *) keys
-		      acceptedTypes: (NSArray *) types
+                               path: (NSString *) p
+                            toArray: (NSMutableArray *) keys
+                      acceptedTypes: (NSArray *) types
                            withPeek: (BOOL) withPeek;
 
 @end

--- a/SoObjects/Mailer/SOGoMailObject.m
+++ b/SoObjects/Mailer/SOGoMailObject.m
@@ -516,12 +516,15 @@ static BOOL debugSoParts       = NO;
   return s;
 }
 
+/* This is defined before the public version without parentMimeType
+   argument to be able to call it recusiverly */
 /* bulk fetching of plain/text content */
 - (void) addRequiredKeysOfStructure: (NSDictionary *) info
-			       path: (NSString *) p
-			    toArray: (NSMutableArray *) keys
-		      acceptedTypes: (NSArray *) types
+                               path: (NSString *) p
+                            toArray: (NSMutableArray *) keys
+                      acceptedTypes: (NSArray *) types
                            withPeek: (BOOL) withPeek
+                    parentMultipart: (NSString *) parentMPart
 {
   /* 
      This is used to collect the set of IMAP4 fetch-keys required to fetch
@@ -536,6 +539,7 @@ static BOOL debugSoParts       = NO;
   id body;
   NSString *bodyToken, *sp, *mimeType;
   id childInfo;
+  NSString *multipart;
 
   bodyToken = (withPeek ? @"body.peek" : @"body");
 
@@ -543,6 +547,12 @@ static BOOL debugSoParts       = NO;
 			[info valueForKey: @"type"],
 			[info valueForKey: @"subtype"]]
 	       lowercaseString];
+
+  if ([[info valueForKey: @"type"] isEqualToString: @"multipart"])
+    multipart = mimeType;
+  else
+    multipart = parentMPart;
+  
   if ([types containsObject: mimeType])
     {
       if ([p length] > 0)
@@ -557,7 +567,8 @@ static BOOL debugSoParts       = NO;
 	  k = [NSString stringWithFormat: @"%@[text]", bodyToken];
 	}
       [keys addObject: [NSDictionary dictionaryWithObjectsAndKeys: k, @"key",
-				     mimeType, @"mimeType", nil]];
+                                     mimeType, @"mimeType",
+                                     multipart, @"multipartMimeType", nil]];
     }
 
   parts = [info objectForKey: @"parts"];
@@ -571,9 +582,11 @@ static BOOL debugSoParts       = NO;
       childInfo = [parts objectAtIndex: i];
       
       [self addRequiredKeysOfStructure: childInfo
-	    path: sp toArray: keys
-	    acceptedTypes: types
-            withPeek: withPeek];
+                                  path: sp
+                               toArray: keys
+                         acceptedTypes: types
+                              withPeek: withPeek
+                             parentMultipart: multipart];
     }
       
   /* check body */
@@ -597,10 +610,26 @@ static BOOL debugSoParts       = NO;
       else
 	sp = [p length] > 0 ? (id)[p stringByAppendingString: @".1"] : (id)@"1";
       [self addRequiredKeysOfStructure: body
-	    path: sp toArray: keys
-	    acceptedTypes: types
-            withPeek: withPeek];
+                                  path: sp
+                               toArray: keys
+                         acceptedTypes: types
+                              withPeek: withPeek
+                       parentMultipart: multipart];
     }
+}
+
+- (void) addRequiredKeysOfStructure: (NSDictionary *) info
+                               path: (NSString *) p
+                            toArray: (NSMutableArray *) keys
+                      acceptedTypes: (NSArray *) types
+                           withPeek: (BOOL) withPeek
+{
+  [self addRequiredKeysOfStructure: (NSDictionary *) info
+                              path: (NSString *) p
+                           toArray: (NSMutableArray *) keys
+                     acceptedTypes: (NSArray *) types
+                          withPeek: (BOOL) withPeek
+                   parentMultipart: @""];
 }
 
 - (NSArray *) plainTextContentFetchKeys


### PR DESCRIPTION
Instead of treating all the message either as alternative or mixed with
this changeset the MIME type of the parent part is used.
This allows a correct disposition of the message in the cases when
nested multiparts elements are used.
Also in mixed parts we convert between plain text and HTML as needed

This PR assumes that #245 has already been merged

NEWS line suggested:
* Correct display of mail with complicate multipart structure