### PR TITLE
Support for groups using EnableDomainBasedUID configuration

### DIFF
--- a/SoObjects/SOGo/SOGoGroup.m
+++ b/SoObjects/SOGo/SOGoGroup.m
@@ -61,6 +61,7 @@
 
 #include "SOGoCache.h"
 #include "SOGoSource.h"
+#include "SOGoSystemDefaults.h"
 #include "SOGoUserManager.h"
 #include "SOGoUser.h"
 
@@ -108,13 +109,29 @@
 + (id) groupWithIdentifier: (NSString *) theID
                   inDomain: (NSString *) domain
 {
-  NSString *uid;
+  NSRange r;
+  NSString *uid, *inDomain;
+  SOGoSystemDefaults *sd;
 
   uid = [theID hasPrefix: @"@"] ? [theID substringFromIndex: 1] : theID;
+  inDomain = domain;
+
+  sd = [SOGoSystemDefaults sharedSystemDefaults];
+  if ([sd enableDomainBasedUID])
+    {
+      /* Split domain from uid */
+      r = [uid rangeOfString: @"@" options: NSBackwardsSearch];
+      if (r.location != NSNotFound)
+        {
+          if (!domain)
+            inDomain = [uid substringFromIndex: r.location + 1];
+          uid = [uid substringToIndex: r.location];
+        }
+    }
 
   return [SOGoGroup groupWithValue: uid
                  andSourceSelector: @selector (lookupGroupEntryByUID:inDomain:)
-                          inDomain: domain];
+                          inDomain: inDomain];
 }
 
 + (id) groupWithEmail: (NSString *) theEmail


### PR DESCRIPTION
Using LDAP as source, the group entry must have a valid
group objectClass such as posixGroup or group and have a
valid UIDField which does not include the domain.

With this changeset, SOGo is aware of these groups when it has
an email and you can share a component such as a calendar with
the member of the group.

`NEWS` in *Enhancements* section:
* Support to groups for `EnableDomainBasedUID` configuration