### PR TITLE
oc: Use enum mapistore_error instead of int

### DIFF
--- a/OpenChange/MAPIStoreAppointmentWrapper.h
+++ b/OpenChange/MAPIStoreAppointmentWrapper.h
@@ -68,105 +68,105 @@
 - (void) fillMessageData: (struct mapistore_message *) dataPtr
                 inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getPidTagSenderEmailAddress: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSenderAddressType: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSenderName: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSenderEntryId: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSenderEmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSenderAddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSenderName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSenderEntryId: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getPidTagReceivedByAddressType: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagReceivedByEmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagReceivedByName: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagReceivedByEntryId: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagReceivedByAddressType: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagReceivedByEmailAddress: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagReceivedByName: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagReceivedByEntryId: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getPidTagIconIndex: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagOwnerAppointmentId: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidMeetingType: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagMessageClass: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagStartDate: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentSequence: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentStateFlags: (void **) data
+- (enum mapistore_error) getPidTagIconIndex: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagOwnerAppointmentId: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidMeetingType: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagStartDate: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentSequence: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentStateFlags: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidResponseStatus: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx;
+
+- (enum mapistore_error) getPidLidAppointmentStartWhole: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidCommonStart: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagEndDate: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentEndWhole: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidCommonEnd: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentDuration: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentSubType: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidBusyStatus: (void **) data // TODO
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidIndentedBusyStatus: (void **) data // TODO
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data // SUMMARY
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidLocation: (void **) data // LOCATION
+                                  inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
+                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSensitivity: (void **) data // not implemented, depends on CLASS
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagBody: (void **) data
                               inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidResponseStatus: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx;
-
-- (int) getPidLidAppointmentStartWhole: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidCommonStart: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagEndDate: (void **) data
-            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentEndWhole: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidCommonEnd: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentDuration: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentSubType: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidBusyStatus: (void **) data // TODO
-                   inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidIndentedBusyStatus: (void **) data // TODO
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagNormalizedSubject: (void **) data // SUMMARY
-                          inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidLocation: (void **) data // LOCATION
-                 inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
-                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSensitivity: (void **) data // not implemented, depends on CLASS
-                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagImportance: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagBody: (void **) data
-         inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidIsRecurring: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidRecurring: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentRecur: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidGlobalObjectId: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidCleanGlobalObjectId: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidServerProcessed: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidServerProcessingActions: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidAppointmentReplyTime: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidIsRecurring: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidRecurring: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentRecur: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidGlobalObjectId: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidCleanGlobalObjectId: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidServerProcessed: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidServerProcessingActions: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidAppointmentReplyTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* reminders */
-- (int) getPidLidReminderSet: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderDelta: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderTime: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderSignalTime: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderOverride: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderType: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderPlaySound: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidReminderFileParameter: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderSet: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderDelta: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderTime: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderSignalTime: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderOverride: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderType: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderPlaySound: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidReminderFileParameter: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
 
 @end
 

--- a/OpenChange/MAPIStoreAppointmentWrapper.m
+++ b/OpenChange/MAPIStoreAppointmentWrapper.m
@@ -452,8 +452,8 @@ static NSCharacterSet *hexCharacterSet = nil;
     }
 }
 
-- (int) getPidTagIconIndex: (void **) data // TODO
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data // TODO
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t longValue;
 
@@ -518,10 +518,10 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagOwnerAppointmentId: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOwnerAppointmentId: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   const char *utf8UID;
   union {
     uint32_t longValue;
@@ -549,8 +549,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidLidMeetingType: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidMeetingType: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* TODO
      See 2.2.6.5 PidLidMeetingType (OXOCAL) */
@@ -559,10 +559,10 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidOwnerCriticalChange: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidOwnerCriticalChange: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   NSCalendarDate *lastModified;
 
   if ([[event attendees] count] > 0)
@@ -578,10 +578,10 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidLidAttendeeCriticalChange: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAttendeeCriticalChange: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   NSCalendarDate *lastModified;
 
   if ([[event attendees] count] > 0)
@@ -597,8 +597,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   const char *className;
 
@@ -644,30 +644,30 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidAppointmentMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = talloc_strdup (memCtx, "IPM.Appointment");
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidFInvited: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFInvited: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidAppointmentSequence: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentSequence: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, [[event sequence] unsignedIntValue]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidAppointmentStateFlags: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentStateFlags: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t flags = 0x00;
 
@@ -684,8 +684,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidResponseStatus: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidResponseStatus: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t status = 0x00;
   iCalPerson *person;
@@ -722,14 +722,14 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
  
-- (int) getPidLidAppointmentNotAllowPropose: (void **) data
-                                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentNotAllowPropose: (void **) data
+                                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidAppointmentStartWhole: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentStartWhole: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
 
@@ -744,8 +744,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagStartDate: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagStartDate: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* "The PidTagStartDate property ([MS-OXPROPS] section 2.1077) SHOULD be
      set, and when set, it MUST be equal to the value of the
@@ -764,8 +764,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidCommonStart: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCommonStart: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
 
@@ -777,8 +777,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidClipStart: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidClipStart: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue, *start;
@@ -806,8 +806,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidLidAppointmentEndWhole: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentEndWhole: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
   NSInteger offset;
@@ -827,8 +827,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagEndDate: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagEndDate: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
   NSInteger offset;
@@ -847,8 +847,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidCommonEnd: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCommonEnd: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
   NSInteger offset;
@@ -868,8 +868,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidClipEnd: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidClipEnd: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
@@ -896,10 +896,10 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) _getEntryIdFromCN: (NSString *) cn
-                 andEmail: (NSString *) email
-                   inData: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getEntryIdFromCN: (NSString *) cn
+                                  andEmail: (NSString *) email
+                                    inData: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *username;
   SOGoUserManager *mgr;
@@ -921,11 +921,11 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) _getEmailAddress: (void **) data
-           forICalPerson: (iCalPerson *) person
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getEmailAddress: (void **) data
+                            forICalPerson: (iCalPerson *) person
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   NSString *email;
 
   email = [person rfc822Email];
@@ -940,20 +940,20 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) _getAddrType: (void **) data
-       forICalPerson: (iCalPerson *) person
-            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getAddrType: (void **) data
+                        forICalPerson: (iCalPerson *) person
+                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"SMTP" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) _getName: (void **) data
-   forICalPerson: (iCalPerson *) person
-        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getName: (void **) data
+                    forICalPerson: (iCalPerson *) person
+                         inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   NSString *cn;
 
   cn = [person cn];
@@ -968,11 +968,11 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) _getEntryId: (void **) data
-      forICalPerson: (iCalPerson *) person
-           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getEntryId: (void **) data
+                       forICalPerson: (iCalPerson *) person
+                            inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   NSString *email, *cn;
 
   if (person)
@@ -991,32 +991,32 @@ static NSCharacterSet *hexCharacterSet = nil;
 }
 
 /* sender (organizer) */
-- (int) getPidTagSenderEmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderEmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEmailAddress: data
                   forICalPerson: [event organizer]
                        inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderAddressType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderAddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getAddrType: data
               forICalPerson: [event organizer]
                    inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderName: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getName: data
           forICalPerson: [event organizer]
                inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderEntryId: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderEntryId: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEntryId: data
              forICalPerson: [event organizer]
@@ -1024,57 +1024,57 @@ static NSCharacterSet *hexCharacterSet = nil;
 }
 
 /* sender representing */
-- (int) getPidTagSentRepresentingEmailAddress: (void **) data
-                                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingEmailAddress: (void **) data
+                                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderEmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingAddressType: (void **) data
-                                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingAddressType: (void **) data
+                                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingName: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingName: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderName: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingEntryId: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingEntryId: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderEntryId: data inMemCtx: memCtx];
 }
 
 /* attendee */
-- (int) getPidTagReceivedByEmailAddress: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByEmailAddress: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEmailAddress: data
                   forICalPerson: [event userAsAttendee: user]
                        inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByAddressType: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByAddressType: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getAddrType: data
               forICalPerson: [event userAsAttendee: user]
                    inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByName: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByName: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getName: data
-          forICalPerson: [event userAsAttendee: user]
+               forICalPerson: [event userAsAttendee: user]
                inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByEntryId: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByEntryId: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEntryId: data
              forICalPerson: [event userAsAttendee: user]
@@ -1082,8 +1082,8 @@ static NSCharacterSet *hexCharacterSet = nil;
 }
 /* /attendee */
 
-- (int) getPidLidAppointmentDuration: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentDuration: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSTimeInterval timeValue;
 
@@ -1093,16 +1093,16 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidAppointmentSubType: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentSubType: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, [event isAllDay]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidBusyStatus: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidBusyStatus: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint8_t value;
   
@@ -1116,24 +1116,24 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidIndentedBusyStatus: (void **) data // TODO
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidIndentedBusyStatus: (void **) data // TODO
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidBusyStatus: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagNormalizedSubject: (void **) data // SUMMARY
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data // SUMMARY
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[event summary] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidLocation: (void **) data // LOCATION
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidLocation: (void **) data // LOCATION
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSString *location;
 
   location = [event location];
@@ -1145,14 +1145,14 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidLidWhere: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWhere: (void **) data
+                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidLocation: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidServerProcessed: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidServerProcessed: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* TODO: we need to check whether the event has been processed internally by
      SOGo or if it was received only by mail. We only assume the SOGo case
@@ -1160,8 +1160,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidServerProcessingActions: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidServerProcessingActions: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx,
                          0x00000010 /* cpsCreatedOnPrincipal */
@@ -1171,8 +1171,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   if ([event symbolicAccessClass] == iCalAccessPublic)
     return [self getNo: data inMemCtx: memCtx];
@@ -1180,8 +1180,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSensitivity: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* See [MS-OXCICAL] Section 2.1.3.11.20.4 */
   uint32_t v;
@@ -1207,8 +1207,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagImportance: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t v;
   if ([[event priority] isEqualToString: @"9"])
@@ -1223,8 +1223,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidNameKeywords: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameKeywords: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* See [MS-OXCICAL] Section 2.1.3.1.1.20.3 */
   NSArray *categories;
@@ -1239,10 +1239,10 @@ static NSCharacterSet *hexCharacterSet = nil;
     return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagBody: (void **) data
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBody: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   NSRange range;
   NSString *stringValue;
   NSString *trimingString = @"\r\n\n";
@@ -1270,8 +1270,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidTagInternetCodepage: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInternetCodepage: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* ref:
      http://msdn.microsoft.com/en-us/library/dd317756%28v=vs.85%29.aspx
@@ -1286,16 +1286,16 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidRecurring: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidRecurring: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, [event isRecurrent]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidIsRecurring: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidIsRecurring: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx,
                          [event isRecurrent]
@@ -1304,16 +1304,16 @@ static NSCharacterSet *hexCharacterSet = nil;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidIsException: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidIsException: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, [event recurrenceId] != nil);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidExceptionReplaceTime: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidExceptionReplaceTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
@@ -1333,8 +1333,8 @@ static NSCharacterSet *hexCharacterSet = nil;
   return rc;
 }
 
-- (int) getPidLidRecurrencePattern: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidRecurrencePattern: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"No description" asUnicodeInMemCtx: memCtx];
 
@@ -1569,10 +1569,10 @@ ExtendedException: (1)
 ReservedBlockEE2Size: 00 00 00 00
 */
 
-- (int) getPidLidAppointmentRecur: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentRecur: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if ([event isRecurrent])
     *data = [self _computeAppointmentRecurInMemCtx: memCtx];
@@ -1582,10 +1582,10 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidRecurrenceType: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidRecurrenceType: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   iCalRecurrenceFrequency freq;
   iCalRecurrenceRule *rrule;
   enum RecurrenceType rectype;
@@ -1614,7 +1614,7 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-// - (int) getPidLidGlobalObjectId: (void **) data
+// - (enum mapistore_error) getPidLidGlobalObjectId: (void **) data
 //                        inMemCtx: (TALLOC_CTX *) memCtx
 // {
 //   static char byteArrayId[] = {0x04, 0x00, 0x00, 0x00, 0x82, 0x00, 0xE0,
@@ -1776,10 +1776,10 @@ ReservedBlockEE2Size: 00 00 00 00
   talloc_free (localMemCtx);
 }
 
-- (int) getPidLidGlobalObjectId: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidGlobalObjectId: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if (!globalObjectId)
     [self _computeGlobalObjectIds];
@@ -1792,10 +1792,10 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidCleanGlobalObjectId: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCleanGlobalObjectId: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if (!cleanGlobalObjectId)
     [self _computeGlobalObjectIds];
@@ -1808,8 +1808,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidAppointmentReplyTime: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentReplyTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* We always return LAST-MODIFIED, which is a hack, but one that works
      because: the user is either (NOT recipient OR (is recipient AND its
@@ -1817,7 +1817,7 @@ ReservedBlockEE2Size: 00 00 00 00
      client OR the user is recipient and its status is defined, where this
      value is thus correct because the recipient status is the only property
      that can be changed. */
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   NSCalendarDate *lastModified;
 
   lastModified = [event lastModified];
@@ -1860,8 +1860,8 @@ ReservedBlockEE2Size: 00 00 00 00
   alarmSet = YES;
 }
 
-- (int) getPidLidReminderSet: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderSet: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!alarmSet)
     [self _setupAlarm];
@@ -1871,8 +1871,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidReminderTime: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderTime: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!alarmSet)
     [self _setupAlarm];
@@ -1882,10 +1882,10 @@ ReservedBlockEE2Size: 00 00 00 00
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidReminderDelta: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderDelta: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   iCalTrigger *trigger;
   NSCalendarDate *startDate, *relationDate, *alarmDate;
   NSTimeInterval interval;
@@ -1922,10 +1922,10 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidReminderSignalTime: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderSignalTime: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSCalendarDate *alarmDate;
 
   if (!alarmSet)
@@ -1942,10 +1942,10 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidReminderOverride: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderOverride: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if (!alarmSet)
     [self _setupAlarm];
@@ -1958,10 +1958,10 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidReminderPlaySound: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderPlaySound: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if (!alarmSet)
     [self _setupAlarm];
@@ -1974,8 +1974,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidReminderFileParameter: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderFileParameter: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   // if (!alarmSet)
   //   [self _setupAlarm];
@@ -1983,14 +1983,14 @@ ReservedBlockEE2Size: 00 00 00 00
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidReminderType: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderType: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidTimeZoneDescription: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTimeZoneDescription: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
   NSString *tzid;
@@ -2007,8 +2007,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidTimeZoneStruct: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTimeZoneStruct: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
 
@@ -2018,8 +2018,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidAppointmentTimeZoneDefinitionStartDisplay: (void **) data
-                                                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentTimeZoneDefinitionStartDisplay: (void **) data
+                                                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
 
@@ -2040,8 +2040,8 @@ ReservedBlockEE2Size: 00 00 00 00
   return rc;
 }
 
-- (int) getPidLidAppointmentTimeZoneDefinitionEndDisplay: (void **) data
-                                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentTimeZoneDefinitionEndDisplay: (void **) data
+                                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidAppointmentTimeZoneDefinitionStartDisplay: data
                                                          inMemCtx: memCtx];

--- a/OpenChange/MAPIStoreAttachment.h
+++ b/OpenChange/MAPIStoreAttachment.h
@@ -36,13 +36,13 @@
 - (void) setAID: (uint32_t) newAID;
 - (uint32_t) AID;
 
-- (int) openEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
-                    withMID: (uint64_t *) mid
-           withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
-                   inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) createEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
-             withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
-                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) openEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
+                                     withMID: (uint64_t *) mid
+                            withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) createEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
+                              withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* helpers */
 - (NSData *) mimeAttachTag;

--- a/OpenChange/MAPIStoreAttachment.m
+++ b/OpenChange/MAPIStoreAttachment.m
@@ -67,40 +67,40 @@
   return mimeAttachTag;
 }
 
-- (int) getPidTagMid: (void **) data
-            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMid: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, [container objectId]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachNumber: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachNumber: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, aid);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagRenderingPosition: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRenderingPosition: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0xffffffff);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAccessLevel: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccessLevel: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) openEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
-                    withMID: (uint64_t *) mid
-           withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) openEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
+                                     withMID: (uint64_t *) mid
+                            withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreEmbeddedMessage *attMessage;
   struct mapistore_message *mapistoreMsg;
@@ -118,9 +118,9 @@
   return (attMessage ? MAPISTORE_SUCCESS : MAPISTORE_ERROR);
 }
 
-- (int) createEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
-             withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) createEmbeddedMessage: (MAPIStoreEmbeddedMessage **) messagePtr
+                              withMAPIStoreMsg: (struct mapistore_message **) mapistoreMsgPtr
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreEmbeddedMessage *attMessage;
   struct mapistore_message *mapistoreMsg;

--- a/OpenChange/MAPIStoreCalendarAttachment.m
+++ b/OpenChange/MAPIStoreCalendarAttachment.m
@@ -94,64 +94,64 @@
            flattenedValuesForKey: @""];
 }
 
-- (int) getPidTagAttachmentHidden: (void **) data
-                         inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachmentHidden: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   return [self getYes: data inMemCtx: localMemCtx];
 }
 
-- (int) getPidTagAttachmentFlags: (void **) data
-                        inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachmentFlags: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   *data = MAPILongValue (localMemCtx, 0x00000002); /* afException */
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachmentLinkId: (void **) data
-                         inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachmentLinkId: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   return [self getLongZero: data inMemCtx: localMemCtx];
 }
 
-- (int) getPidTagAttachFlags: (void **) data
-                    inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachFlags: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   return [self getLongZero: data inMemCtx: localMemCtx];
 }
 
-- (int) getPidTagAttachMethod: (void **) data
-                     inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachMethod: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   *data = MAPILongValue (localMemCtx, afEmbeddedMessage);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachEncoding: (void **) data
-                      inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagAttachEncoding: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   *data = [[NSData data] asBinaryInMemCtx: localMemCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   *data = [@"Untitled" asUnicodeInMemCtx: localMemCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachmentContactPhoto: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachmentContactPhoto: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagExceptionReplaceTime: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagExceptionReplaceTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
@@ -178,8 +178,8 @@
   return rc;
 }
 
-- (int) getPidTagExceptionStartTime: (void **) data
-                           inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagExceptionStartTime: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;
@@ -205,8 +205,8 @@
   return rc;
 }
 
-- (int) getPidTagExceptionEndTime: (void **) data
-                         inMemCtx: (TALLOC_CTX *) localMemCtx
+- (enum mapistore_error) getPidTagExceptionEndTime: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) localMemCtx
 {
   enum mapistore_error rc;
   NSCalendarDate *dateValue;

--- a/OpenChange/MAPIStoreCalendarEmbeddedMessage.m
+++ b/OpenChange/MAPIStoreCalendarEmbeddedMessage.m
@@ -89,73 +89,73 @@
   *dataPtr = msgData;
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = talloc_strdup (memCtx, "IPM.OLE.CLASS.{00061055-0000-0000-C000-000000000046}");
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageFlags: (void **) data // TODO
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageFlags: (void **) data // TODO
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, MSGFLAG_UNMODIFIED);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagResponseRequested: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagResponseRequested: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
 /* discarded properties */
 
-- (int) getPidLidAppointmentLastSequence: (void **)
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentLastSequence: (void **)
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidMeetingWorkspaceUrl: (void **)
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidMeetingWorkspaceUrl: (void **)
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidContacts: (void **)
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidContacts: (void **)
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagSensitivity: (void **)
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **)
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidPrivate: (void **)
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPrivate: (void **)
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidNameKeywords: (void **)
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameKeywords: (void **)
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidFExceptionalBody: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFExceptionalBody: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }

--- a/OpenChange/MAPIStoreCalendarFolder.m
+++ b/OpenChange/MAPIStoreCalendarFolder.m
@@ -193,16 +193,16 @@
             [(SOGoAppointmentFolder *) sogoObject aclSQLListingFilter]];
 }
 
-- (int) getPidTagContainerClass: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContainerClass: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPF.Appointment" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDefaultPostMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDefaultPostMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Appointment" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreCalendarMessage.m
+++ b/OpenChange/MAPIStoreCalendarMessage.m
@@ -228,8 +228,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
 
 
 /* getters */
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   SOGoUser *owner;
 
@@ -242,8 +242,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidSideEffects: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSideEffects: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx,
                          seOpenToDelete | seOpenToCopy | seOpenToMove
@@ -252,7 +252,7 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
@@ -347,8 +347,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   *dataPtr = msgData;
 }
 
-- (int) getPidTagResponseRequested: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagResponseRequested: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
@@ -358,8 +358,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
    MAPIStoreMessage base class, then the proxy method is not reached
    (see MAPIStoreObject).
 */
-- (int) getPidTagNormalizedSubject: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreAppointmentWrapper *appointmentWrapper;
 
@@ -370,8 +370,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagSensitivity: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreAppointmentWrapper *appointmentWrapper;
 
@@ -382,8 +382,8 @@ static Class NSArrayK, MAPIStoreAppointmentWrapperK;
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagImportance: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreAppointmentWrapper *appointmentWrapper;
 

--- a/OpenChange/MAPIStoreContactsAttachment.m
+++ b/OpenChange/MAPIStoreContactsAttachment.m
@@ -92,52 +92,52 @@
   return [container lastModificationTime];
 }
 
-- (int) getPidTagAttachEncoding: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagAttachEncoding: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
 {
   *data = [[NSData data] asBinaryInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachFlags: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachFlags: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttachmentFlags: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachmentFlags: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttachmentHidden: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachmentHidden: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttachmentLinkId: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachmentLinkId: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttachMethod: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachMethod: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x00000001);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachmentContactPhoto: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachmentContactPhoto: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttachDataBinary: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachDataBinary: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!photoData)
     ASSIGN (photoData,
@@ -148,8 +148,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachSize: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachSize: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!photoData)
     ASSIGN (photoData,
@@ -160,16 +160,16 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachExtension: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachExtension: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self fileExtension] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachLongFilename: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachLongFilename: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *filename;
 
@@ -181,15 +181,15 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachFilename: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachFilename: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagAttachLongFilename: data
                                   inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagAttachLongFilename: data inMemCtx: memCtx];
 }

--- a/OpenChange/MAPIStoreContactsFolder.m
+++ b/OpenChange/MAPIStoreContactsFolder.m
@@ -117,8 +117,8 @@
   return [[self activeUserRoles] containsObject: SOGoRole_ObjectViewer];
 }
 
-- (int) getPidTagDefaultPostMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDefaultPostMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Contact" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreContactsMessage.m
+++ b/OpenChange/MAPIStoreContactsMessage.m
@@ -104,8 +104,8 @@
   return element;
 }
 
-- (int) getPidTagIconIndex: (void **) data // TODO
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data // TODO
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* see http://msdn.microsoft.com/en-us/library/cc815472.aspx */
   *data = MAPILongValue (memCtx, 0x00000200);
@@ -113,52 +113,52 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAlternateRecipientAllowed: (void **) data
-                                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAlternateRecipientAllowed: (void **) data
+                                                   inMemCtx: (TALLOC_CTX *) memCtx
 
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMessageFlags: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageFlags: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, MSGFLAG_READ);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDeleteAfterSubmit: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDeleteAfterSubmit: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = talloc_strdup (memCtx, "IPM.Contact");
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSendInternetEncoding: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSendInternetEncoding: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x00065001);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagNormalizedSubject: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagDisplayName: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidFileUnder: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFileUnder: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *surName, *givenName, *middleName;
   NSMutableString *fileUnder;
@@ -184,22 +184,22 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidFileUnderId: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFileUnderId: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x00008017); /* what ol2003 sets */
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAccount: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccount: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidEmail1EmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagContactEmailAddresses: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContactEmailAddresses: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -212,8 +212,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagEmsAbTargetAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagEmsAbTargetAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -224,8 +224,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSearchKey: (void **) data // TODO
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSearchKey: (void **) data // TODO
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -236,16 +236,16 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMailPermission: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMailPermission: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagBody: (void **) data
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBody: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSString *stringValue;
 
   stringValue = [[sogoObject vCard] note];
@@ -257,8 +257,8 @@
   return rc;
 }
 
-- (int) getPidTagSensitivity: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
@@ -267,8 +267,8 @@
 // Contact Name Properties [MS-OXOCNTC 2.2.1.1]
 // ---------------------------------------------------------
 
-- (int) getPidTagNickname: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNickname: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -278,8 +278,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagGeneration: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagGeneration: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -291,8 +291,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSurname: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSurname: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -304,8 +304,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMiddleName: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMiddleName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -317,8 +317,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagGivenName: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagGivenName: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -330,8 +330,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDisplayNamePrefix: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayNamePrefix: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -398,9 +398,9 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   Store on *data the given email (position)
   It can return MAPISTORE_ERR_NOT_FOUND if the email doesn't exist
 */
-- (int) _getPidLidEmailAddress: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
-                    atPosition: (NSUInteger) position
+- (enum mapistore_error) _getPidLidEmailAddress: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
+                                     atPosition: (NSUInteger) position
 {
   NSString *email;
 
@@ -412,60 +412,60 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidEmail1EmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail1EmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailAddress: data inMemCtx: memCtx atPosition: 1];
 }
 
-- (int) getPidLidEmail2EmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail2EmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailAddress: data inMemCtx: memCtx atPosition: 2];
 }
 
-- (int) getPidLidEmail3EmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail3EmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailAddress: data inMemCtx: memCtx atPosition: 3];
 }
 
-- (int) getPidLidEmail1OriginalDisplayName: (void **) data
-                                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail1OriginalDisplayName: (void **) data
+                                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidEmail1EmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidEmail2OriginalDisplayName: (void **) data
-                                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail2OriginalDisplayName: (void **) data
+                                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidEmail2EmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidEmail3OriginalDisplayName: (void **) data
-                                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail3OriginalDisplayName: (void **) data
+                                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidEmail3EmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidEmail1AddressType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail1AddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (![self _fetchEmailAddress: 1]) return MAPISTORE_ERR_NOT_FOUND;
 
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidEmail2AddressType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail2AddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (![self _fetchEmailAddress: 2]) return MAPISTORE_ERR_NOT_FOUND;
 
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidEmail3AddressType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail3AddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (![self _fetchEmailAddress: 3]) return MAPISTORE_ERR_NOT_FOUND;
 
@@ -476,9 +476,9 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   Store on *data a string with the display name for the given email (position)
   It can return MAPISTORE_ERR_NOT_FOUND if the email doesn't exist
 */
-- (int) _getPidLidEmailDisplayName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
-                        atPosition: (NSUInteger) position
+- (enum mapistore_error) _getPidLidEmailDisplayName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
+                                         atPosition: (NSUInteger) position
 {
   NGVCard *vCard;
   NSString *fn, *email;
@@ -495,20 +495,20 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidEmail1DisplayName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail1DisplayName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailDisplayName: data inMemCtx: memCtx atPosition: 1];
 }
 
-- (int) getPidLidEmail2DisplayName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail2DisplayName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailDisplayName: data inMemCtx: memCtx atPosition: 2];
 }
 
-- (int) getPidLidEmail3DisplayName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail3DisplayName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailDisplayName: data inMemCtx: memCtx atPosition: 3];
 }
@@ -544,9 +544,9 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   Store on *data an entryId for the given email (position)
   It can return MAPISTORE_ERR_NOT_FOUND if the email doesn't exist
 */
-- (int) _getPidLidEmailOriginalEntryId: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
-                            atPosition: (NSUInteger) position
+- (enum mapistore_error) _getPidLidEmailOriginalEntryId: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
+                                             atPosition: (NSUInteger) position
 {
   NSData *value;
 
@@ -558,36 +558,36 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidEmail1OriginalEntryId: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail1OriginalEntryId: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailOriginalEntryId: data
                                      inMemCtx: memCtx
                                    atPosition: 1];
 }
 
-- (int) getPidLidEmail2OriginalEntryId: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail2OriginalEntryId: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailOriginalEntryId: data
                                      inMemCtx: memCtx
                                    atPosition: 2];
 }
 
-- (int) getPidLidEmail3OriginalEntryId: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidEmail3OriginalEntryId: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getPidLidEmailOriginalEntryId: data
                                      inMemCtx: memCtx
                                    atPosition: 3];
 }
 
-- (int) _getElement: (NSString *) elementTag
-             ofType: (NSString *) aType
-          excluding: (NSString *) aTypeToExclude
-              atPos: (NSUInteger) pos
-             inData: (void **) data
-           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getElement: (NSString *) elementTag
+                              ofType: (NSString *) aType
+                           excluding: (NSString *) aTypeToExclude
+                               atPos: (NSUInteger) pos
+                              inData: (void **) data
+                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSArray *elements;
   CardElement *ce;
@@ -618,8 +618,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagBusinessFaxNumber: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBusinessFaxNumber: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"fax" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
@@ -656,8 +656,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return list;
 }
 
-- (int) getPidLidAddressBookProviderArrayType: (void **) data
-                                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAddressBookProviderArrayType: (void **) data
+                                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   // [MS-OXOCNTC] 2.2.1.2.12
   // https://msdn.microsoft.com/en-us/library/ee218011%28v=exchg.80%29.aspx
@@ -677,8 +677,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
     return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidLidAddressBookProviderEmailList: (void **) data
-                                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAddressBookProviderEmailList: (void **) data
+                                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSArray *emailList = [self _buildAddressBookProviderEmailList];
 
@@ -697,49 +697,49 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 
 // Home Address
 
-- (int) getPidTagHomeAddressStreet: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressStreet: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 2 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHomeAddressCity: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressCity: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 3 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHomeAddressStateOrProvince: (void **) data
-                                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressStateOrProvince: (void **) data
+                                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 4 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHomeAddressPostalCode: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressPostalCode: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 5 inData: data inMemCtx: memCtx];
 }
-- (int) getPidTagHomeAddressCountry: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressCountry: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 6 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHomeAddressPostOfficeBox: (void **) data
-                                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeAddressPostOfficeBox: (void **) data
+                                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"home" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidHomeAddress: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidHomeAddress: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"label" ofType: @"home" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
@@ -747,50 +747,50 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 
 // Work Address
 
-- (int) getPidLidWorkAddressStreet: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressStreet: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 2 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddressCity: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressCity: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 3 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddressState: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressState: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 4 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddressPostalCode: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressPostalCode: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 5 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddressCountry: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressCountry: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 6 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddressPostOfficeBox: (void **) data
-                                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddressPostOfficeBox: (void **) data
+                                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"work" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidWorkAddress: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidWorkAddress: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"label" ofType: @"work" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
@@ -798,57 +798,57 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 
 // Mailing Address
 
-- (int) getPidTagStreetAddress: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagStreetAddress: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 2 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagLocality: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagLocality: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 3 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagStateOrProvince: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagStateOrProvince: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 4 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagPostalCode: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPostalCode: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 5 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagCountry: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagCountry: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 6 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagPostOfficeBox: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPostOfficeBox: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"adr" ofType: @"pref" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagPostalAddress: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPostalAddress: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"label" ofType: @"pref" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidPostalAddressId: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPostalAddressId: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSArray *elements;
   CardElement *element;
@@ -878,36 +878,36 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 // Telephone Properties [MS-OXOCNTC 2.2.1.4]
 // -------------------------------------------------------
 
-- (int) getPidTagPagerTelephoneNumber: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPagerTelephoneNumber: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"pager" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagBusinessTelephoneNumber: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBusinessTelephoneNumber: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"work" excluding: @"fax"
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHomeTelephoneNumber: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHomeTelephoneNumber: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"home" excluding: @"fax"
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagPrimaryTelephoneNumber: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPrimaryTelephoneNumber: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"pref" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMobileTelephoneNumber: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMobileTelephoneNumber: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"tel" ofType: @"cell" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
@@ -917,12 +917,12 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 // Event Properties [MS-OXOCNTC 2.2.1.5]
 // ---------------------------------------------------------
 
-- (int) getPidTagBirthday: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBirthday: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[sogoObject vCard] bday];
   if ([stringValue length] != 0)
@@ -938,12 +938,12 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidTagWeddingAnniversary: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagWeddingAnniversary: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSCalendarDate *dateValue;
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"x-ms-anniversary"]
                   flattenedValuesForKey: @""];
@@ -963,8 +963,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 // Professional Properties [MS-OXOCNTC 2.2.1.6]
 // ---------------------------------------------------------
 
-- (int) getPidTagTitle: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagTitle: (void **) data
+                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -974,8 +974,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagCompanyName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagCompanyName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   CardElement *org;
 
@@ -986,8 +986,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDepartmentName: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDepartmentName: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   CardElement *org;
 
@@ -998,11 +998,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagOfficeLocation: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOfficeLocation: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"x-ms-office"]
                   flattenedValuesForKey: @""];
@@ -1014,11 +1014,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidTagManagerName: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagManagerName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"x-ms-manager"]
                   flattenedValuesForKey: @""];
@@ -1030,11 +1030,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidTagAssistant: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAssistant: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"x-ms-assistant"]
                   flattenedValuesForKey: @""];
@@ -1046,11 +1046,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidTagProfession: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagProfession: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[sogoObject vCard] role];
   if (stringValue)
@@ -1089,8 +1089,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   fetchedAttachments = YES;
 }
 
-- (int) getPidLidHasPicture: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidHasPicture: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!fetchedAttachments)
     [self _fetchAttachmentParts];
@@ -1163,11 +1163,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
 // Other Properties [MS-OXOCNTC 2.2.1.10]
 // ---------------------------------------------------------
 
-- (int) getPidTagSpouseName: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSpouseName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"x-ms-spouse"]
                   flattenedValuesForKey: @""];
@@ -1179,8 +1179,8 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidLidInstantMessagingAddress: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidInstantMessagingAddress: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -1193,11 +1193,11 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidFreeBusyLocation: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFreeBusyLocation: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   stringValue = [[[sogoObject vCard] uniqueChildWithTag: @"fburl"]
                   flattenedValuesForKey: @""];
@@ -1209,15 +1209,15 @@ enum {  // [MS-OXOCNTC] 2.2.1.2.11
   return rc;
 }
 
-- (int) getPidTagPersonalHomePage: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPersonalHomePage: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"url" ofType: @"home" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagBusinessHomePage: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBusinessHomePage: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getElement: @"url" ofType: @"work" excluding: nil
                      atPos: 0 inData: data inMemCtx: memCtx];

--- a/OpenChange/MAPIStoreContext.h
+++ b/OpenChange/MAPIStoreContext.h
@@ -72,10 +72,10 @@
                                   forUser: (NSString *) username
                                  withRole: (enum mapistore_context_role) role;
 
-+ (int) openContext: (MAPIStoreContext **) contextPtr
-            withURI: (const char *) newUri
-     connectionInfo: (struct mapistore_connection_info *) newConnInfo
-     andTDBIndexing: (struct indexing_context *) indexing;
++ (enum mapistore_error) openContext: (MAPIStoreContext **) contextPtr
+                             withURI: (const char *) newUri
+                      connectionInfo: (struct mapistore_connection_info *) newConnInfo
+                      andTDBIndexing: (struct indexing_context *) indexing;
 
 - (id)   initFromURL: (NSURL *) newUri
   withConnectionInfo: (struct mapistore_connection_info *) newConnInfo
@@ -91,11 +91,11 @@
 // - (id) lookupObject: (NSString *) objectURLString;
 
 /* backend methods */
-- (int) getPath: (char **) path
-         ofFMID: (uint64_t) fmid
-       inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getRootFolder: (MAPIStoreFolder **) folderPtr
-              withFID: (uint64_t) fmid;
+- (enum mapistore_error) getPath: (char **) path
+                          ofFMID: (uint64_t) fmid
+                        inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getRootFolder: (MAPIStoreFolder **) folderPtr
+                               withFID: (uint64_t) fmid;
 
 /* util methods */
 - (NSString *) extractChildNameFromURL: (NSString *) childURL

--- a/OpenChange/MAPIStoreContext.m
+++ b/OpenChange/MAPIStoreContext.m
@@ -212,16 +212,16 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   return completeURL;
 }
 
-+ (int) openContext: (MAPIStoreContext **) contextPtr
-            withURI: (const char *) newUri
-     connectionInfo: (struct mapistore_connection_info *) newConnInfo
-     andTDBIndexing: (struct indexing_context *) indexing
++ (enum mapistore_error) openContext: (MAPIStoreContext **) contextPtr
+                             withURI: (const char *) newUri
+                      connectionInfo: (struct mapistore_connection_info *) newConnInfo
+                      andTDBIndexing: (struct indexing_context *) indexing
 {
   MAPIStoreContext *context;
   Class contextClass;
   NSString *module;
   NSURL *baseURL;
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
 
   context = nil;
 
@@ -338,11 +338,11 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
   return activeUser;
 }
 
-- (int) getPath: (char **) path
-         ofFMID: (uint64_t) fmid
-       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPath: (char **) path
+                          ofFMID: (uint64_t) fmid
+                        inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   NSString *objectURL, *url;
 
   url = [contextUrl absoluteString];
@@ -379,8 +379,8 @@ static inline NSURL *CompleteURLFromMapistoreURI (const char *uri)
 {
 }
 
-- (int) getRootFolder: (MAPIStoreFolder **) folderPtr
-              withFID: (uint64_t) newFid
+- (enum mapistore_error) getRootFolder: (MAPIStoreFolder **) folderPtr
+                               withFID: (uint64_t) newFid
 {
   enum mapistore_error rc;
   MAPIStoreFolder *baseFolder;

--- a/OpenChange/MAPIStoreDBMessage.m
+++ b/OpenChange/MAPIStoreDBMessage.m
@@ -282,7 +282,7 @@
 // We might get there if for some reasons, all classes weren't able
 // to tell us the message class.
 //
-- (int) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Note" asUnicodeInMemCtx: memCtx];
 
@@ -291,10 +291,10 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getProperties: (struct mapistore_property_data *) data
-             withTags: (enum MAPITAGS *) tags
-             andCount: (uint16_t) columnCount
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperties: (struct mapistore_property_data *) data
+                              withTags: (enum MAPITAGS *) tags
+                              andCount: (uint16_t) columnCount
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   [sogoObject reloadIfNeeded];
 
@@ -304,12 +304,12 @@
                      inMemCtx: memCtx];
 }
 
-- (int) getProperty: (void **) data
-            withTag: (enum MAPITAGS) propTag
-           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperty: (void **) data
+                             withTag: (enum MAPITAGS) propTag
+                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   id value;
-  int rc;
+  enum mapistore_error rc;
  
   value = [properties objectForKey: MAPIPropertyKey (propTag)];
   if (value)

--- a/OpenChange/MAPIStoreEmbeddedMessage.m
+++ b/OpenChange/MAPIStoreEmbeddedMessage.m
@@ -56,81 +56,81 @@ static Class MAPIStoreAttachmentK;
            idForObjectWithKey: objectKey];
 }
 
-- (int) getPidTagAccessLevel: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccessLevel: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
 /* disabled properties */
-- (int) getPidTagFolderId: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFolderId: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagChangeKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagSourceKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSourceKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagParentSourceKey: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagParentSourceKey: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagChangeNumber: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeNumber: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagInstID: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInstID: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagInstanceNum: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInstanceNum: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagRowType: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRowType: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagDepth: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDepth: (void **) data
+                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagIconIndex: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagGenerateExchangeViews: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagGenerateExchangeViews: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagOriginalMessageClass: (void **) dataa
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalMessageClass: (void **) dataa
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }

--- a/OpenChange/MAPIStoreFAIMessage.m
+++ b/OpenChange/MAPIStoreFAIMessage.m
@@ -45,8 +45,8 @@
                          andType: MAPISTORE_FAI_TABLE];
 }
 
-- (int) getPidTagAssociated: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAssociated: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }

--- a/OpenChange/MAPIStoreFolder.h
+++ b/OpenChange/MAPIStoreFolder.h
@@ -96,34 +96,34 @@
 
 /* backend interface */
 
-- (int) openFolder: (MAPIStoreFolder **) childFolderPtr
-           withFID: (uint64_t) fid;
-- (int) createFolder: (MAPIStoreFolder **) childFolderPtr
-             withRow: (struct SRow *) aRow
-              andFID: (uint64_t) fid;
-- (int) deleteFolder;
-- (int) getChildCount: (uint32_t *) rowCount
-          ofTableType: (enum mapistore_table_type) tableType;
+- (enum mapistore_error) openFolder: (MAPIStoreFolder **) childFolderPtr
+                            withFID: (uint64_t) fid;
+- (enum mapistore_error) createFolder: (MAPIStoreFolder **) childFolderPtr
+                              withRow: (struct SRow *) aRow
+                               andFID: (uint64_t) fid;
+- (enum mapistore_error) deleteFolder;
+- (enum mapistore_error) getChildCount: (uint32_t *) rowCount
+                           ofTableType: (enum mapistore_table_type) tableType;
 
-- (int) createMessage: (MAPIStoreMessage **) messagePtr
-              withMID: (uint64_t) mid
-         isAssociated: (BOOL) isAssociated;
+- (enum mapistore_error) createMessage: (MAPIStoreMessage **) messagePtr
+                               withMID: (uint64_t) mid
+                          isAssociated: (BOOL) isAssociated;
 
-- (int) openMessage: (MAPIStoreMessage **) messagePtr
-            withMID: (uint64_t) mid
-         forWriting: (BOOL) readWrite
-           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) deleteMessageWithMID: (uint64_t) mid
-                    andFlags: (uint8_t) flags;
+- (enum mapistore_error) openMessage: (MAPIStoreMessage **) messagePtr
+                             withMID: (uint64_t) mid
+                          forWriting: (BOOL) readWrite
+                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) deleteMessageWithMID: (uint64_t) mid
+                                     andFlags: (uint8_t) flags;
 
-- (int) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
-                        andCount: (uint32_t) count
-                      fromFolder: (MAPIStoreFolder *) sourceFolder
-                        withMIDs: (uint64_t *) targetMids
-                   andChangeKeys: (struct Binary_r **) targetChangeKeys
-       andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
-                        wantCopy: (uint8_t) want_copy
-                        inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
+                                         andCount: (uint32_t) count
+                                       fromFolder: (MAPIStoreFolder *) sourceFolder
+                                         withMIDs: (uint64_t *) targetMids
+                                    andChangeKeys: (struct Binary_r **) targetChangeKeys
+                        andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
+                                         wantCopy: (uint8_t) want_copy
+                                         inMemCtx: (TALLOC_CTX *) memCtx;
 
 - (enum mapistore_error) moveCopyToFolder: (MAPIStoreFolder *) targetFolder
                               withNewName: (NSString *) newFolderName
@@ -131,20 +131,20 @@
                               isRecursive: (BOOL) isRecursive
                           inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getDeletedFMIDs: (struct UI8Array_r **) fmidsPtr
-                  andCN: (uint64_t *) cnPtr
-       fromChangeNumber: (uint64_t) changeNum
-            inTableType: (enum mapistore_table_type) tableType
-               inMemCtx: (TALLOC_CTX *) mem_ctx;
+- (enum mapistore_error) getDeletedFMIDs: (struct UI8Array_r **) fmidsPtr
+                                   andCN: (uint64_t *) cnPtr
+                        fromChangeNumber: (uint64_t) changeNum
+                             inTableType: (enum mapistore_table_type) tableType
+                                inMemCtx: (TALLOC_CTX *) mem_ctx;
 
-- (int) getTable: (MAPIStoreTable **) tablePtr
-     andRowCount: (uint32_t *) count
-       tableType: (enum mapistore_table_type) tableType
-     andHandleId: (uint32_t) handleId;
+- (enum mapistore_error) getTable: (MAPIStoreTable **) tablePtr
+                      andRowCount: (uint32_t *) count
+                        tableType: (enum mapistore_table_type) tableType
+                      andHandleId: (uint32_t) handleId;
 
-- (int) modifyPermissions: (struct PermissionData *) permissions
-                withCount: (uint16_t) pcount
-                 andFlags: (int8_t) flags;
+- (enum mapistore_error) modifyPermissions: (struct PermissionData *) permissions
+                                 withCount: (uint16_t) pcount
+                                  andFlags: (int8_t) flags;
 - (enum mapistore_error) preloadMessageBodiesWithMIDs: (const struct UI8Array_r *) mids
                                           ofTableType: (enum mapistore_table_type) tableType;
 

--- a/OpenChange/MAPIStoreFolder.m
+++ b/OpenChange/MAPIStoreFolder.m
@@ -365,10 +365,10 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return foundObject;
 }
 
-- (int) openFolder: (MAPIStoreFolder **) childFolderPtr
-           withFID: (uint64_t) fid
+- (enum mapistore_error) openFolder: (MAPIStoreFolder **) childFolderPtr
+                            withFID: (uint64_t) fid
 {
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   MAPIStoreFolder *childFolder;
   MAPIStoreMapping *mapping;
   NSString *childURL;
@@ -390,9 +390,9 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) createFolder: (MAPIStoreFolder **) childFolderPtr
-             withRow: (struct SRow *) aRow
-              andFID: (uint64_t) fid
+- (enum mapistore_error) createFolder: (MAPIStoreFolder **) childFolderPtr
+                              withRow: (struct SRow *) aRow
+                               andFID: (uint64_t) fid
 {
   BOOL mapped;
   enum mapistore_error rc = MAPISTORE_SUCCESS;
@@ -447,7 +447,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) deleteFolder
+- (enum mapistore_error) deleteFolder
 {
   // TODO: raise exception in case underlying delete fails?
   // [propsMessage delete];
@@ -458,11 +458,11 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getChildCount: (uint32_t *) rowCount
-          ofTableType: (enum mapistore_table_type) tableType
+- (enum mapistore_error) getChildCount: (uint32_t *) rowCount
+                           ofTableType: (enum mapistore_table_type) tableType
 {
   NSArray *keys;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   //[self logWithFormat: @"METHOD '%s' (%d) -- tableType: %d",
 	//__FUNCTION__, __LINE__, tableType];
@@ -483,16 +483,16 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) openMessage: (MAPIStoreMessage **) messagePtr
-            withMID: (uint64_t) mid
-         forWriting: (BOOL) readWrite
-           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) openMessage: (MAPIStoreMessage **) messagePtr
+                             withMID: (uint64_t) mid
+                          forWriting: (BOOL) readWrite
+                            inMemCtx: (TALLOC_CTX *) memCtx;
 {
   NSString *messageURL;
   MAPIStoreMapping *mapping;
   MAPIStoreMessage *message;
   SOGoUser *ownerUser;
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
 
   mapping = [self mapping];
   messageURL = [mapping urlFromID: mid];
@@ -523,9 +523,9 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) createMessage: (MAPIStoreMessage **) messagePtr
-              withMID: (uint64_t) mid
-         isAssociated: (BOOL) isAssociated
+- (enum mapistore_error) createMessage: (MAPIStoreMessage **) messagePtr
+                               withMID: (uint64_t) mid
+                          isAssociated: (BOOL) isAssociated
 {
   enum mapistore_error rc;
   MAPIStoreMessage *message;
@@ -570,8 +570,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) deleteMessageWithMID: (uint64_t) mid
-                    andFlags: (uint8_t) flags
+- (enum mapistore_error) deleteMessageWithMID: (uint64_t) mid
+                                     andFlags: (uint8_t) flags
 {
   NSString *childURL;
   MAPIStoreMapping *mapping;
@@ -580,7 +580,7 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   NSUInteger count, max;
   id msgObject;
   SOGoUser *ownerUser;
-  int rc;
+  enum mapistore_error rc;
 
   /* flags that control the behaviour of the operation
      (MAPISTORE_SOFT_DELETE or MAPISTORE_PERMANENT_DELETE) */
@@ -638,15 +638,15 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
 }
 
 // private method
-- (int) _moveCopyMessageWithMID: (uint64_t) srcMid
-                     fromFolder: (MAPIStoreFolder *) sourceFolder
-                        withMID: (uint64_t) targetMid
-                   andChangeKey: (struct Binary_r *) targetChangeKey
-       andPredecessorChangeList: (struct Binary_r *) targetPredecessorChangeList
-                       wantCopy: (uint8_t) wantCopy
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _moveCopyMessageWithMID: (uint64_t) srcMid
+                                      fromFolder: (MAPIStoreFolder *) sourceFolder
+                                         withMID: (uint64_t) targetMid
+                                    andChangeKey: (struct Binary_r *) targetChangeKey
+                        andPredecessorChangeList: (struct Binary_r *) targetPredecessorChangeList
+                                        wantCopy: (uint8_t) wantCopy
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   MAPIStoreMessage *sourceMsg, *destMsg;
   //TALLOC_CTX *memCtx;
   struct SRow aRow;
@@ -695,16 +695,16 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
-                        andCount: (uint32_t) midCount
-                      fromFolder: (MAPIStoreFolder *) sourceFolder
-                        withMIDs: (uint64_t *) targetMids
-                   andChangeKeys: (struct Binary_r **) targetChangeKeys
-       andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
-                        wantCopy: (uint8_t) wantCopy
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
+                                         andCount: (uint32_t) midCount
+                                       fromFolder: (MAPIStoreFolder *) sourceFolder
+                                         withMIDs: (uint64_t *) targetMids
+                                    andChangeKeys: (struct Binary_r **) targetChangeKeys
+                        andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
+                                         wantCopy: (uint8_t) wantCopy
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSUInteger count;
   NSMutableArray *oldMessageURLs;
   NSString *oldMessageURL;
@@ -957,13 +957,13 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
                 withIDs: newIDs];
 }
 
-- (int) getDeletedFMIDs: (struct UI8Array_r **) fmidsPtr
-                  andCN: (uint64_t *) cnPtr
-       fromChangeNumber: (uint64_t) changeNum
-            inTableType: (enum mapistore_table_type) tableType
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getDeletedFMIDs: (struct UI8Array_r **) fmidsPtr
+                                   andCN: (uint64_t *) cnPtr
+                        fromChangeNumber: (uint64_t) changeNum
+                             inTableType: (enum mapistore_table_type) tableType
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   NSString *baseURL, *format, *url;
   NSArray *keys;
   NSNumber *cnNbr;
@@ -1016,12 +1016,12 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) getTable: (MAPIStoreTable **) tablePtr
-     andRowCount: (uint32_t *) countPtr
-       tableType: (enum mapistore_table_type) tableType
-     andHandleId: (uint32_t) handleId
+- (enum mapistore_error) getTable: (MAPIStoreTable **) tablePtr
+                      andRowCount: (uint32_t *) countPtr
+                        tableType: (enum mapistore_table_type) tableType
+                      andHandleId: (uint32_t) handleId
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   MAPIStoreTable *table;
   SOGoUser *ownerUser;
 
@@ -1208,16 +1208,16 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   // folderKeys = nil;
 }
 
-- (int) getPidTagParentFolderId: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagParentFolderId: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, [container objectId]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagFolderId: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFolderId: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, [self objectId]);
 
@@ -1234,8 +1234,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   0x00000010 Create Contents Table
   0x00000020 Create Associated Contents Table
 */
-- (int) getPidTagAccess: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccess: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t access = 0;
   SOGoUser *ownerUser;
@@ -1263,8 +1263,8 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagRights: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRights: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t rights = 0;
   SOGoUser *ownerUser;
@@ -1292,74 +1292,74 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAccessControlListData: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccessControlListData: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[NSData data] asBinaryInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttributeHidden: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttributeHidden: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttributeSystem: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttributeSystem: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagAttributeReadOnly: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttributeReadOnly: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSubfolders: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSubfolders: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, [self supportsSubFolders] && [[self folderKeys] count] > 0);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagFolderChildCount: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFolderChildCount: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, [[self folderKeys] count]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagContentCount: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContentCount: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, [[self messageKeys] count]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagContentUnreadCount: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContentUnreadCount: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAssociatedContentCount: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAssociatedContentCount: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, [[self faiMessageKeys] count]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDeletedCountTotal: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDeletedCountTotal: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* TODO */
   *data = MAPILongValue (memCtx, 0);
@@ -1367,10 +1367,10 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagLocalCommitTimeMax: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagLocalCommitTimeMax: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSDate *date;
 
   date = [self lastMessageModificationTime];
@@ -1382,18 +1382,18 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   return rc;
 }
 
-- (int) getPidTagDefaultPostMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDefaultPostMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Note" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getProperties: (struct mapistore_property_data *) data
-             withTags: (enum MAPITAGS *) tags
-             andCount: (uint16_t) columnCount
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperties: (struct mapistore_property_data *) data
+                              withTags: (enum MAPITAGS *) tags
+                              andCount: (uint16_t) columnCount
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   [dbFolder reloadIfNeeded];
 
@@ -1403,11 +1403,11 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
                      inMemCtx: memCtx];
 }
 
-- (int) getProperty: (void **) data
-            withTag: (enum MAPITAGS) propTag
-           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperty: (void **) data
+                             withTag: (enum MAPITAGS) propTag
+                            inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   id value;
 
   value = [properties objectForKey: MAPIPropertyKey (propTag)];
@@ -1614,9 +1614,9 @@ Class NSExceptionK, MAPIStoreFAIMessageK, MAPIStoreMessageTableK, MAPIStoreFAIMe
   [users release];
 }
 
-- (int) modifyPermissions: (struct PermissionData *) permissions
-                withCount: (uint16_t) pcount
-                 andFlags: (int8_t) flags
+- (enum mapistore_error) modifyPermissions: (struct PermissionData *) permissions
+                                 withCount: (uint16_t) pcount
+                                  andFlags: (int8_t) flags
 {
   NSUInteger count, propCount;
   struct PermissionData *currentPermission;

--- a/OpenChange/MAPIStoreGCSFolder.m
+++ b/OpenChange/MAPIStoreGCSFolder.m
@@ -86,9 +86,9 @@ static Class NSNumberK;
   [super dealloc];
 }
 
-- (int) deleteFolder
+- (enum mapistore_error) deleteFolder
 {
-  int rc;
+  enum mapistore_error rc;
   NSException *error;
   NSString *name;
 
@@ -138,8 +138,8 @@ static Class NSNumberK;
     [sogoObject renameTo: newDisplayName];
 }
 
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *displayName;
   Class cClass;

--- a/OpenChange/MAPIStoreGCSMessage.m
+++ b/OpenChange/MAPIStoreGCSMessage.m
@@ -54,8 +54,8 @@
   return [sogoObject lastModified];
 }
 
-- (int) getPidTagAccess: (void **) data // TODO
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccess: (void **) data // TODO
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreContext *context;
   WOContext *woContext;
@@ -91,8 +91,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAccessLevel: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccessLevel: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStoreContext *context;
   MAPIStoreUserContext *userContext;
@@ -120,10 +120,10 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagChangeKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSData *changeKey;
   MAPIStoreGCSFolder *parentFolder;
   NSString *nameInContainer;
@@ -155,10 +155,10 @@
   return rc;
 }
 
-- (int) getPidTagPredecessorChangeList: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPredecessorChangeList: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSData *changeList;
   MAPIStoreGCSFolder *parentFolder;
 

--- a/OpenChange/MAPIStoreMailAttachment.m
+++ b/OpenChange/MAPIStoreMailAttachment.m
@@ -76,24 +76,24 @@
   ASSIGN (bodyPart, newBodyPart);
 }
 
-- (int) getPidTagAttachMethod: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachMethod: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x00000001); // afByValue
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachTag: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachTag: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self mimeAttachTag] asBinaryInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachSize: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachSize: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t longValue;
 
@@ -103,8 +103,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagRecordKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRecordKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   static char recordBytes[] = {0xd9, 0xd8, 0x11, 0xa3, 0xe2, 0x90, 0x18, 0x41,
                                0x9e, 0x04, 0x58, 0x46, 0x9d, 0x6d, 0x1b,
@@ -121,16 +121,16 @@
   return [bodyInfo filename];
 }
 
-- (int) getPidTagAttachLongFilename: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachLongFilename: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self _fileName] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachFilename: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachFilename: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *fileName, *baseName, *ext;
 
@@ -149,8 +149,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *fileName;
 
@@ -165,8 +165,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachContentId: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachContentId: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[bodyInfo objectForKey: @"bodyId"]
             asUnicodeInMemCtx: memCtx];
@@ -174,8 +174,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachMimeTag: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachMimeTag: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *mimeTag, *fileName;
 
@@ -193,8 +193,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAttachDataBinary: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAttachDataBinary: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[bodyPart fetchBLOBWithPeek: YES] asBinaryInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreMailFolder.m
+++ b/OpenChange/MAPIStoreMailFolder.m
@@ -208,9 +208,9 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   return rc;
 }
 
-- (int) deleteFolder
+- (enum mapistore_error) deleteFolder
 {
-  int rc;
+  enum mapistore_error rc;
   NSException *error;
   NSString *name;
 
@@ -234,8 +234,8 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   return (rc == MAPISTORE_SUCCESS) ? [super deleteFolder] : rc;
 }
 
-- (int) getPidTagContentUnreadCount: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContentUnreadCount: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   EOQualifier *searchQualifier;
   uint32_t longValue;
@@ -250,8 +250,8 @@ static Class SOGoMailFolderK, MAPIStoreMailFolderK, MAPIStoreOutboxFolderK;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagContainerClass: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagContainerClass: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPF.Note" asUnicodeInMemCtx: memCtx];
 
@@ -1363,15 +1363,14 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
 // Move (or eventually copy) the mails identified by
 // "srcMids" from the source folder into this folder.
 //
-- (int) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
-                        andCount: (uint32_t) midCount
-                      fromFolder: (MAPIStoreFolder *) sourceFolder
-                        withMIDs: (uint64_t *) targetMids
-                   andChangeKeys: (struct Binary_r **) targetChangeKeys
-       andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
-                        wantCopy: (uint8_t) wantCopy
-                        inMemCtx: (TALLOC_CTX *) memCtx
-
+- (enum mapistore_error) moveCopyMessagesWithMIDs: (uint64_t *) srcMids
+                                         andCount: (uint32_t) midCount
+                                       fromFolder: (MAPIStoreFolder *) sourceFolder
+                                         withMIDs: (uint64_t *) targetMids
+                                    andChangeKeys: (struct Binary_r **) targetChangeKeys
+                        andPredecessorChangeLists: (struct Binary_r **) targetPredecessorChangeLists
+                                         wantCopy: (uint8_t) wantCopy
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   NGImap4Connection *connection;
   NGImap4Client *client;
@@ -1767,8 +1766,8 @@ _parseCOPYUID (NSString *line, NSArray **destUIDsP)
 
 @implementation MAPIStoreOutboxFolder
 
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"Outbox" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -57,27 +57,27 @@
 
 - (NSString *) subject;
 
-- (int) getPidTagIconIndex: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagFlagStatus: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagIconIndex: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagFlagStatus: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getPidTagMessageFlags: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagFollowupIcon: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagImportance: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagReceivedByEmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSenderEmailAddress: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagDisplayTo: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagDisplayCc: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagDisplayBcc: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagMessageFlags: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagFollowupIcon: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagReceivedByEmailAddress: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSenderEmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagDisplayTo: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagDisplayCc: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagDisplayBcc: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* batch-mode helpers */
 - (void) setBodyContentFromRawData: (NSArray *) rawContent;

--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -482,10 +482,10 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return appointmentWrapper;
 }
 
-- (int) getPidTagChangeKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSData *changeKey;
   MAPIStoreMailFolder *parentFolder;
   NSString *nameInContainer;
@@ -518,10 +518,10 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-- (int) getPidTagPredecessorChangeList: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPredecessorChangeList: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSData *changeList;
 
   if (isNew)
@@ -597,8 +597,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return version;
 }
 
-- (int) getPidTagIconIndex: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t longValue;
 
@@ -626,16 +626,16 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidResponseStatus: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidResponseStatus: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidImapDeleted: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidImapDeleted: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t longValue;
 
@@ -648,8 +648,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSubjectPrefix: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSubjectPrefix: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *subject;
   NSUInteger colIdx;
@@ -670,8 +670,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagNormalizedSubject: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue, *subject;
   NSUInteger quoteStartIdx, quoteEndIdx, colIdx;
@@ -719,14 +719,14 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidFInvited: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidFInvited: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -742,8 +742,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagReplyRequested: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReplyRequested: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -753,38 +753,38 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidTagResponseRequested: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagResponseRequested: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagReplyRequested: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagLatestDeliveryTime: (void **) data // DOUBT
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagLatestDeliveryTime: (void **) data // DOUBT
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagCreationTime: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagOriginalSubmitTime: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalSubmitTime: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagCreationTime: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagClientSubmitTime: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagClientSubmitTime: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagCreationTime: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMessageDeliveryTime: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageDeliveryTime: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagCreationTime: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagMessageFlags: (void **) data // TODO
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageFlags: (void **) data // TODO
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSDictionary *coreInfos;
   NSArray *flags;
@@ -807,8 +807,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagFlagStatus: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFlagStatus: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSDictionary *coreInfos;
   NSArray *flags;
@@ -827,8 +827,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagFollowupIcon: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFollowupIcon: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSDictionary *coreInfos;
   NSArray *flags;
@@ -847,45 +847,45 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSensitivity: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagOriginalSensitivity: (void **) data // TODO
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalSensitivity: (void **) data // TODO
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSensitivity: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingAddressType: (void **) data
-                                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingAddressType: (void **) data
+                                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedRepresentingAddressType: (void **) data
-                                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedRepresentingAddressType: (void **) data
+                                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByAddressType: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByAddressType: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderAddressType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderAddressType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getSMTPAddrType: data inMemCtx: memCtx];
 }
 
-- (int) _getEmailAddressFromEmail: (NSString *) fullMail
-                           inData: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getEmailAddressFromEmail: (NSString *) fullMail
+                                            inData: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   NGMailAddress *ngAddress;
   NSString *email;
@@ -905,9 +905,9 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) _getCNFromEmail: (NSString *) fullMail
-                 inData: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getCNFromEmail: (NSString *) fullMail
+                                  inData: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   NGMailAddress *ngAddress;
   NSString *cn;
@@ -935,16 +935,16 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) _getEntryIdFromEmail: (NSString *) fullMail
-                      inData: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) _getEntryIdFromEmail: (NSString *) fullMail
+                                       inData: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *username, *cn, *email;
   SOGoUserManager *mgr;
   NSDictionary *contactInfos;
   NGMailAddress *ngAddress;
   NSData *entryId;
-  int rc;
+  enum mapistore_error rc;
 
   if (fullMail)
     {
@@ -981,111 +981,111 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-- (int) getPidTagSenderEmailAddress: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderEmailAddress: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEmailAddressFromEmail: [sogoObject from]
                                   inData: data
                                 inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderName: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getCNFromEmail: [sogoObject from]
                         inData: data
                       inMemCtx: memCtx];
 }
 
-- (int) getPidTagSenderEntryId: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSenderEntryId: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEntryIdFromEmail: [sogoObject from]
                              inData: data
                            inMemCtx: memCtx];
 }
 
-- (int) getPidTagOriginalAuthorName: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalAuthorName: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderEmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingEmailAddress: (void **) data
-                                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingEmailAddress: (void **) data
+                                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderEmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingName: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingName: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderName: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSentRepresentingEntryId: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSentRepresentingEntryId: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSenderEntryId: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByEmailAddress: (void **) data
-                               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByEmailAddress: (void **) data
+                                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEmailAddressFromEmail: [sogoObject to]
                                   inData: data
                                 inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByName: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByName: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getCNFromEmail: [sogoObject to]
                         inData: data
                       inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedByEntryId: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedByEntryId: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getEntryIdFromEmail: [sogoObject to]
                              inData: data
                            inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedRepresentingName: (void **) data
-                                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedRepresentingName: (void **) data
+                                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagReceivedByName: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedRepresentingEmailAddress: (void **) data
-                                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedRepresentingEmailAddress: (void **) data
+                                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagReceivedByEmailAddress: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagReceivedRepresentingEntryId: (void **) data
-                                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReceivedRepresentingEntryId: (void **) data
+                                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagReceivedByEntryId: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayTo: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayTo: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[sogoObject to] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagOriginalDisplayTo: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalDisplayTo: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagDisplayTo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayCc: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayCc: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -1098,34 +1098,34 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagOriginalDisplayCc: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalDisplayCc: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagDisplayCc: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayBcc: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayBcc: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getEmptyString: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagOriginalDisplayBcc: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalDisplayBcc: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagDisplayBcc: data inMemCtx: memCtx];
 }
 
-- (int) getPidNameContentType: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameContentType: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"message/rfc822" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagImportance: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t v;
   NSString *s;
@@ -1143,8 +1143,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagInternetCodepage: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInternetCodepage: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSNumber *codepage;
 
@@ -1161,11 +1161,11 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagBody: (void **) data
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBody: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSData *textContent;
-  int rc;
+  enum mapistore_error rc;
 
   if (!bodySetup)
     [self _fetchBodyData];
@@ -1200,11 +1200,11 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-- (int) getPidTagHtml: (void **) data
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHtml: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSData *htmlContent;
-  int rc;
+  enum mapistore_error rc;
 
   if (!bodySetup)
     [self _fetchBodyData];
@@ -1231,36 +1231,36 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-- (int) getPidTagRtfCompressed: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRtfCompressed: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = NULL;
 
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagRtfInSync: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRtfInSync: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagInternetMessageId: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInternetMessageId: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[sogoObject messageId] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagReadReceiptRequested: (void **) data // TODO
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagReadReceiptRequested: (void **) data // TODO
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidGlobalObjectId: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidGlobalObjectId: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1271,8 +1271,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidCleanGlobalObjectId: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCleanGlobalObjectId: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1283,7 +1283,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidServerProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidServerProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1294,7 +1294,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidServerProcessingActions: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidServerProcessingActions: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1305,9 +1305,9 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagProcessed: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
 
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1320,7 +1320,7 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-// - (int) getPidLidServerProcessed: (void **) data
+// - (enum mapistore_error) getPidLidServerProcessed: (void **) data
 //                         inMemCtx: (TALLOC_CTX *) memCtx
 // {
 //   if (!headerSetup)
@@ -1332,8 +1332,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
 //           : MAPISTORE_ERR_NOT_FOUND);
 // }
 
-- (int) getPidLidPrivate: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPrivate: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1344,8 +1344,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           :  [self getNo: data inMemCtx: memCtx]);
 }
 
-- (int) getPidTagMessageEditorFormat: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageEditorFormat: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t format;
 
@@ -1364,33 +1364,33 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidReminderSet: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidReminderSet: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidUseTnef: (void **) data // TODO
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidUseTnef: (void **) data // TODO
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidRemoteStatus: (void **) data // TODO
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidRemoteStatus: (void **) data // TODO
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidAgingDontAgeMe: (void **) data // TODO
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAgingDontAgeMe: (void **) data // TODO
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
 /* event getters */
-- (int) getPidTagStartDate: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagStartDate: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1400,10 +1400,10 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidAppointmentMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1416,8 +1416,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
   return rc;
 }
 
-- (int) getPidLidAppointmentStartWhole: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentStartWhole: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1428,8 +1428,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidCommonStart: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCommonStart: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1440,8 +1440,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidTagEndDate: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagEndDate: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1451,8 +1451,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidAppointmentEndWhole: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentEndWhole: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1463,8 +1463,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidCommonEnd: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCommonEnd: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1475,8 +1475,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidAppointmentDuration: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentDuration: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1487,8 +1487,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidAppointmentSubType: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentSubType: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1499,8 +1499,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidBusyStatus: (void **) data // TODO
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidBusyStatus: (void **) data // TODO
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1511,8 +1511,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidLocation: (void **) data // LOCATION
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidLocation: (void **) data // LOCATION
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1523,8 +1523,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidIsRecurring: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidIsRecurring: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1535,8 +1535,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidRecurring: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidRecurring: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1547,8 +1547,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidAppointmentRecur: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAppointmentRecur: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1559,8 +1559,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidTagOwnerAppointmentId: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOwnerAppointmentId: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1571,8 +1571,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidLidMeetingType: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidMeetingType: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!headerSetup)
     [self _fetchHeaderData];
@@ -1583,8 +1583,8 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
           : MAPISTORE_ERR_NOT_FOUND);
 }
 
-- (int) getPidTagTransportMessageHeaders: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagTransportMessageHeaders: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSDictionary *mailHeaders;
   NSEnumerator *keyEnumerator;

--- a/OpenChange/MAPIStoreMailMessageTable.m
+++ b/OpenChange/MAPIStoreMailMessageTable.m
@@ -340,10 +340,10 @@ static Class MAPIStoreMailMessageK, NSDataK, NSStringK;
   [self cleanupCaches];
 }
 
-- (int) getRow: (struct mapistore_property_data **) dataP
-     withRowID: (uint32_t) rowId
-  andQueryType: (enum mapistore_query_type) queryType
-      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getRow: (struct mapistore_property_data **) dataP
+                      withRowID: (uint32_t) rowId
+                   andQueryType: (enum mapistore_query_type) queryType
+                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   if (!fetchedCoreInfos)
     {
@@ -352,8 +352,8 @@ static Class MAPIStoreMailMessageK, NSDataK, NSStringK;
          prefetchCoreInfosForMessageKeys: [self restrictedChildKeys]];
     }
 
- return [super   getRow: dataP withRowID: rowId
-           andQueryType: queryType inMemCtx: memCtx];
+ return [super getRow: dataP withRowID: rowId
+               andQueryType: queryType inMemCtx: memCtx];
 }
 
 @end

--- a/OpenChange/MAPIStoreMailVolatileMessage.h
+++ b/OpenChange/MAPIStoreMailVolatileMessage.h
@@ -27,7 +27,7 @@
 
 @interface MAPIStoreMailVolatileMessage : MAPIStoreMessage
 
-- (int) submitWithFlags: (enum SubmitFlags) flags;
+- (enum mapistore_error) submitWithFlags: (enum SubmitFlags) flags;
 
 @end
 

--- a/OpenChange/MAPIStoreMailVolatileMessage.m
+++ b/OpenChange/MAPIStoreMailVolatileMessage.m
@@ -290,17 +290,17 @@ static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
           : ULLONG_MAX);
 }
 
-- (int) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Note" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagChangeKey: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeKey: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSData *changeKey;
-  int rc;
+  enum mapistore_error rc;
 
   changeKey = [properties objectForKey: MAPIPropertyKey (PR_CHANGE_KEY)];
   if (changeKey)
@@ -1051,7 +1051,7 @@ MakeMessageBody (NSDictionary *mailProperties, NSDictionary *attachmentParts, NS
   return messageData;
 }
 
-- (int) submitWithFlags: (enum SubmitFlags) flags
+- (enum mapistore_error) submitWithFlags: (enum SubmitFlags) flags
 {
   enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSDictionary *recipients;

--- a/OpenChange/MAPIStoreMessage.h
+++ b/OpenChange/MAPIStoreMessage.h
@@ -48,21 +48,21 @@
 - (void) getMessageData: (struct mapistore_message **) dataPtr
                inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) modifyRecipientsWithRecipients: (struct mapistore_message_recipient *) recipients
-                              andCount: (NSUInteger) max
-                            andColumns: (struct SPropTagArray *) columns;
+- (enum mapistore_error) modifyRecipientsWithRecipients: (struct mapistore_message_recipient *) recipients
+                                               andCount: (NSUInteger) max
+                                             andColumns: (struct SPropTagArray *) columns;
 - (NSArray *) attachmentKeys;
 - (NSArray *) attachmentKeysMatchingQualifier: (EOQualifier *) qualifier
                              andSortOrderings: (NSArray *) sortOrderings;
 - (id) lookupAttachment: (NSString *) childKey;
 
 /* backend methods */
-- (int) createAttachment: (MAPIStoreAttachment **) attachmentPtr
-                   inAID: (uint32_t *) aidPtr;
-- (int) getAttachment: (MAPIStoreAttachment **) attachmentPtr
-              withAID: (uint32_t) aid;
-- (int) getAttachmentTable: (MAPIStoreAttachmentTable **) tablePtr
-               andRowCount: (uint32_t *) countPtr;
+- (enum mapistore_error) createAttachment: (MAPIStoreAttachment **) attachmentPtr
+                                    inAID: (uint32_t *) aidPtr;
+- (enum mapistore_error) getAttachment: (MAPIStoreAttachment **) attachmentPtr
+                               withAID: (uint32_t) aid;
+- (enum mapistore_error) getAttachmentTable: (MAPIStoreAttachmentTable **) tablePtr
+                                andRowCount: (uint32_t *) countPtr;
 - (enum mapistore_error) setReadFlag: (uint8_t) flag;
 - (enum mapistore_error) saveMessage: (TALLOC_CTX *) memCtx;
 

--- a/OpenChange/MAPIStoreMessage.m
+++ b/OpenChange/MAPIStoreMessage.m
@@ -276,9 +276,9 @@ rtf2html (NSData *compressedRTF)
   return recipientProperties;
 }
 
-- (int) modifyRecipientsWithRecipients: (struct mapistore_message_recipient *) newRecipients
-                              andCount: (NSUInteger) max
-                            andColumns: (struct SPropTagArray *) columns;
+- (enum mapistore_error) modifyRecipientsWithRecipients: (struct mapistore_message_recipient *) newRecipients
+                                               andCount: (NSUInteger) max
+                                             andColumns: (struct SPropTagArray *) columns;
 {
   static NSString *recTypes[] = { @"orig", @"to", @"cc", @"bcc" };
   NSDictionary *recipientProperties;
@@ -318,7 +318,7 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) addPropertiesFromRow: (struct SRow *) aRow
+- (enum mapistore_error) addPropertiesFromRow: (struct SRow *) aRow
 {
   enum mapistore_error rc;
   MAPIStoreContext *context;
@@ -397,11 +397,11 @@ rtf2html (NSData *compressedRTF)
   return newAttachment;
 }
 
-- (int) createAttachment: (MAPIStoreAttachment **) attachmentPtr
-                   inAID: (uint32_t *) aidPtr
+- (enum mapistore_error) createAttachment: (MAPIStoreAttachment **) attachmentPtr
+                                    inAID: (uint32_t *) aidPtr
 {
   MAPIStoreAttachment *attachment;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   attachment = [self createAttachment];
   if (attachment)
@@ -422,12 +422,12 @@ rtf2html (NSData *compressedRTF)
   return nil;
 }
 
-- (int) getAttachment: (MAPIStoreAttachment **) attachmentPtr
-              withAID: (uint32_t) aid
+- (enum mapistore_error) getAttachment: (MAPIStoreAttachment **) attachmentPtr
+                               withAID: (uint32_t) aid
 {
   MAPIStoreAttachment *attachment;
   NSArray *keys;
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
 
   keys = [self attachmentKeys];
   if (aid < [keys count])
@@ -443,11 +443,11 @@ rtf2html (NSData *compressedRTF)
   return rc;
 }
 
-- (int) getAttachmentTable: (MAPIStoreAttachmentTable **) tablePtr
-               andRowCount: (uint32_t *) countPtr
+- (enum mapistore_error) getAttachmentTable: (MAPIStoreAttachmentTable **) tablePtr
+                                andRowCount: (uint32_t *) countPtr
 {
   MAPIStoreAttachmentTable *attTable;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   attTable = [self attachmentTable];
   if (attTable)
@@ -582,8 +582,8 @@ rtf2html (NSData *compressedRTF)
 }
 
 /* getters */
-- (int) getPidTagInstID: (void **) data // TODO: DOUBT
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInstID: (void **) data // TODO: DOUBT
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* we return a unique id based on the key */
   *data = MAPILongLongValue (memCtx, [[sogoObject nameInContainer] hash]);
@@ -591,22 +591,22 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagInstanceNum: (void **) data // TODO: DOUBT
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagInstanceNum: (void **) data // TODO: DOUBT
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagRowType: (void **) data // TODO: DOUBT
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagRowType: (void **) data // TODO: DOUBT
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, TBL_LEAF_ROW);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagDepth: (void **) data // TODO: DOUBT
-              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDepth: (void **) data // TODO: DOUBT
+                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, 0);
 
@@ -623,8 +623,8 @@ rtf2html (NSData *compressedRTF)
   0x00000010 Create Contents Table
   0x00000020 Create Associated Contents Table
 */
-- (int) getPidTagAccess: (void **) data
-               inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccess: (void **) data
+                                inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t access = 0;
   BOOL userIsOwner;
@@ -664,8 +664,8 @@ rtf2html (NSData *compressedRTF)
   0x00000000 Read-Only
   0x00000001 Modify
 */
-- (int) getPidTagAccessLevel: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAccessLevel: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t access = 0;
   BOOL userIsOwner;
@@ -684,20 +684,20 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int ) getPidTagHasNamedProperties: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHasNamedProperties: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSideEffects: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSideEffects: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidCurrentVersion: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCurrentVersion: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   // *data = MAPILongValue (memCtx, 115608); // Outlook 11.5608
   *data = MAPILongValue (memCtx, 0x1ce3a); // Outlook 11.8330
@@ -705,34 +705,34 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidCurrentVersionName: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidCurrentVersionName: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"11.0" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidAutoProcessState: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidAutoProcessState: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x00000000);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagFolderId: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagFolderId: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, [container objectId]);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMid: (void **) data
-            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMid: (void **) data
+                             inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   uint64_t obId;
 
   obId = [self objectId];
@@ -747,24 +747,24 @@ rtf2html (NSData *compressedRTF)
   return rc;
 }
 
-- (int) getPidTagMessageLocaleId: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageLocaleId: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x0409);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageFlags: (void **) data // TODO
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageFlags: (void **) data // TODO
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, MSGFLAG_FROMME | MSGFLAG_READ | MSGFLAG_UNMODIFIED);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageSize: (void **) data // TODO
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageSize: (void **) data // TODO
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* TODO: choose another name in SOGo for that method */
   *data = MAPILongValue (memCtx, [[sogoObject davContentLength] intValue]);
@@ -772,30 +772,30 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagImportance: (void **) data // TODO -> subclass?
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagImportance: (void **) data // TODO -> subclass?
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 1);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagPriority: (void **) data // TODO -> subclass?
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagPriority: (void **) data // TODO -> subclass?
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSensitivity: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSensitivity: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSubject: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSubject: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   TALLOC_CTX *localMemCtx;
   char *prefix, *normalizedSubject;
 
@@ -816,71 +816,71 @@ rtf2html (NSData *compressedRTF)
   return rc;
 }
 
-- (int) getPidTagNormalizedSubject: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagOriginalSubject: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalSubject: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagSubject: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagConversationTopic: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagConversationTopic: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagNormalizedSubject: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagSubjectPrefix: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSubjectPrefix: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getEmptyString: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDeleteAfterSubmit: (void **) data // TODO
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDeleteAfterSubmit: (void **) data // TODO
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayTo: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayTo: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getEmptyString: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayCc: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayCc: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getEmptyString: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagDisplayBcc: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayBcc: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getEmptyString: data inMemCtx: memCtx];
 }
 
-// - (int) getPidTagOriginalDisplayTo: (void **) data
+// - (enum mapistore_error) getPidTagOriginalDisplayTo: (void **) data
 // {
 //   return [self getPidTagDisplayTo: data];
 // }
 
-// - (int) getPidTagOriginalDisplayCc: (void **) data
+// - (enum mapistore_error) getPidTagOriginalDisplayCc: (void **) data
 // {
 //   return [self getPidTagDisplayCc: data];
 // }
 
-// - (int) getPidTagOriginalDisplayBcc: (void **) data
+// - (enum mapistore_error) getPidTagOriginalDisplayBcc: (void **) data
 // {
 //   return [self getPidTagDisplayBcc: data];
 // }
 
-- (int) getPidTagLastModifierName: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagLastModifierName: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSURL *contextUrl;
 
@@ -890,22 +890,22 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   [self subclassResponsibility: _cmd];
 
   return MAPISTORE_ERR_NOT_FOUND;
 }
 
-- (int) getPidTagOriginalMessageClass: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagOriginalMessageClass: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getProperty: data withTag: PidTagMessageClass inMemCtx: memCtx];
 }
 
-- (int) getPidTagHasAttachments: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHasAttachments: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx,
                          [[self attachmentKeys] count] > 0);
@@ -913,8 +913,8 @@ rtf2html (NSData *compressedRTF)
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagAssociated: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagAssociated: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];;
 }

--- a/OpenChange/MAPIStoreNotesFolder.m
+++ b/OpenChange/MAPIStoreNotesFolder.m
@@ -30,8 +30,8 @@
 
 @implementation MAPIStoreNotesFolder
 
-- (int) getPidTagDefaultPostMessageClass: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDefaultPostMessageClass: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.StickyNote" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreNotesMessage.m
+++ b/OpenChange/MAPIStoreNotesMessage.m
@@ -32,8 +32,8 @@
 
 @implementation MAPIStoreNotesMessage
 
-- (int) getPidTagIconIndex: (void **) data // TODO
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data // TODO
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* see http://msdn.microsoft.com/en-us/library/cc815472.aspx */
   // *longValue = 0x00000300 for blue
@@ -46,7 +46,7 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.StickyNote" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreObject.h
+++ b/OpenChange/MAPIStoreObject.h
@@ -68,27 +68,27 @@
 - (NSMutableDictionary *) properties;
 
 /* ops */
-- (int) getProperties: (struct mapistore_property_data *) data
-             withTags: (enum MAPITAGS *) tags
-             andCount: (uint16_t) columnCount
-             inMemCtx: (TALLOC_CTX *) localMemCtx;
+- (enum mapistore_error) getProperties: (struct mapistore_property_data *) data
+                              withTags: (enum MAPITAGS *) tags
+                              andCount: (uint16_t) columnCount
+                              inMemCtx: (TALLOC_CTX *) localMemCtx;
 
-- (int) addPropertiesFromRow: (struct SRow *) aRow;
+- (enum mapistore_error) addPropertiesFromRow: (struct SRow *) aRow;
 
-- (int) getProperty: (void **) data
-            withTag: (enum MAPITAGS) propTag
-           inMemCtx: (TALLOC_CTX *) localMemCtx;
+- (enum mapistore_error) getProperty: (void **) data
+                             withTag: (enum MAPITAGS) propTag
+                            inMemCtx: (TALLOC_CTX *) localMemCtx;
 
 /* helper getters */
 - (NSData *) getReplicaKeyFromGlobCnt: (uint64_t) objectCnt;
-- (int) getReplicaKey: (void **) data
-          fromGlobCnt: (uint64_t) objectCnt
-             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getReplicaKey: (void **) data
+                           fromGlobCnt: (uint64_t) objectCnt
+                              inMemCtx: (TALLOC_CTX *) memCtx;
 
-- (int) getPidTagCreationTime: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagLastModificationTime: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagCreationTime: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagLastModificationTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* move and copy operations */
 - (void) copyPropertiesToObject: (MAPIStoreObject *) newObject  inMemCtx: (TALLOC_CTX *) memCtx;

--- a/OpenChange/MAPIStoreObject.m
+++ b/OpenChange/MAPIStoreObject.m
@@ -150,15 +150,15 @@ static Class NSExceptionK, MAPIStoreFolderK;
   return properties;
 }
 
-- (int) getProperty: (void **) data
-            withTag: (enum MAPITAGS) propTag
-           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperty: (void **) data
+                             withTag: (enum MAPITAGS) propTag
+                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   MAPIStorePropertyGetter method = NULL;
   uint16_t propValue;
   SEL methodSel;
   id value;
-  int rc = MAPISTORE_ERR_NOT_FOUND;
+  enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   NSUInteger count, max;
 
   value = [properties objectForKey: MAPIPropertyKey (propTag)];
@@ -186,16 +186,16 @@ static Class NSExceptionK, MAPIStoreFolderK;
   return rc;
 }
 
-- (int) getPidTagCreationTime: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagCreationTime: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self creationTime] asFileTimeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagLastModificationTime: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagLastModificationTime: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self lastModificationTime] asFileTimeInMemCtx: memCtx];
 
@@ -219,10 +219,10 @@ static Class NSExceptionK, MAPIStoreFolderK;
   return canGetProperty;
 }
 
-- (int) getProperties: (struct mapistore_property_data *) data
-             withTags: (enum MAPITAGS *) tags
-             andCount: (uint16_t) columnCount
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getProperties: (struct mapistore_property_data *) data
+                              withTags: (enum MAPITAGS *) tags
+                              andCount: (uint16_t) columnCount
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint16_t count;
 
@@ -239,7 +239,7 @@ static Class NSExceptionK, MAPIStoreFolderK;
   [proxies addObject: newProxy];
 }
 
-- (int) addPropertiesFromRow: (struct SRow *) aRow
+- (enum mapistore_error) addPropertiesFromRow: (struct SRow *) aRow
 {
   struct SPropValue *cValue;
   NSUInteger counter;
@@ -298,9 +298,9 @@ static Class NSExceptionK, MAPIStoreFolderK;
   return replicaKey;
 }
 
-- (int) getReplicaKey: (void **) data
-          fromGlobCnt: (uint64_t) objectCnt
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getReplicaKey: (void **) data
+                           fromGlobCnt: (uint64_t) objectCnt
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[self getReplicaKeyFromGlobCnt: objectCnt] asBinaryInMemCtx: memCtx];
 

--- a/OpenChange/MAPIStoreObjectProxy.m
+++ b/OpenChange/MAPIStoreObjectProxy.m
@@ -51,7 +51,7 @@
   MAPIStorePropertyGetter method;
   uint16_t propValue;
   SEL methodSel;
-  int rc;
+  enum mapistore_error rc;
 
   propValue = (propTag & 0xffff0000) >> 16;
   methodSel = MAPIStoreSelectorForPropertyGetter (propValue);

--- a/OpenChange/MAPIStorePermissionsTable.m
+++ b/OpenChange/MAPIStorePermissionsTable.m
@@ -84,16 +84,16 @@
   return memberId;
 }
 
-- (int) getPidTagMemberId: (void **) data
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMemberId: (void **) data
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongLongValue (memCtx, memberId);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagEntryId: (void **) data
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagEntryId: (void **) data
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSData *entryId;
   struct mapistore_connection_info *connInfo;
@@ -110,8 +110,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMemberName: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMemberName: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *displayName;
 
@@ -127,8 +127,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMemberRights: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMemberRights: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t rights;
   NSArray *roles;

--- a/OpenChange/MAPIStoreSOGo.m
+++ b/OpenChange/MAPIStoreSOGo.m
@@ -256,7 +256,7 @@ sogo_backend_create_context(TALLOC_CTX *mem_ctx,
 {
   NSAutoreleasePool *pool;
   MAPIStoreContext *context;
-  int rc;
+  enum mapistore_error rc;
 
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
@@ -291,7 +291,7 @@ sogo_backend_create_root_folder (const char *username,
   NSAutoreleasePool *pool;
   NSString *userName, *folderName;
   NSString *mapistoreUri;
-  int rc;
+  enum mapistore_error rc;
 
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
@@ -326,7 +326,7 @@ sogo_backend_list_contexts(const char *username, struct indexing_context *indexi
 {
   NSAutoreleasePool *pool;
   NSString *userName;
-  int rc;
+  enum mapistore_error rc;
 
   NS_CURRENT_THREAD_REGISTER();
   pool = [NSAutoreleasePool new];
@@ -372,7 +372,7 @@ sogo_context_get_path(void *backend_object, TALLOC_CTX *mem_ctx,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreContext *context;
-  int rc;
+  enum mapistore_error rc;
 
   if (backend_object)
     {
@@ -404,7 +404,7 @@ sogo_context_get_root_folder(void *backend_object, TALLOC_CTX *mem_ctx,
   NSAutoreleasePool *pool;
   MAPIStoreContext *context;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (backend_object)
     {
@@ -445,7 +445,7 @@ sogo_folder_open_folder(void *folder_object, TALLOC_CTX *mem_ctx, uint64_t fid, 
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder, *childFolder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -487,7 +487,7 @@ sogo_folder_create_folder(void *folder_object, TALLOC_CTX *mem_ctx,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder, *childFolder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -528,7 +528,7 @@ sogo_folder_delete(void *folder_object)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -558,7 +558,7 @@ sogo_folder_get_child_count(void *folder_object, enum mapistore_table_type table
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -592,7 +592,7 @@ sogo_folder_open_message(void *folder_object,
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -632,7 +632,7 @@ sogo_folder_create_message(void *folder_object,
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -666,7 +666,7 @@ sogo_folder_delete_message(void *folder_object, uint64_t mid, uint8_t flags)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -703,7 +703,7 @@ sogo_folder_move_copy_messages(void *folder_object,
   MAPIStoreFolder *sourceFolder, *targetFolder;
   NSAutoreleasePool *pool;
   struct MAPIStoreTallocWrapper *wrapper;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -746,7 +746,7 @@ sogo_folder_move_folder(void *folder_object, void *target_folder_object,
   MAPIStoreFolder *moveFolder, *targetFolder;
   NSString *newFolderName;
   struct MAPIStoreTallocWrapper *wrapper;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -794,7 +794,7 @@ sogo_folder_copy_folder(void *folder_object, void *target_folder_object, TALLOC_
   MAPIStoreFolder *copyFolder, *targetFolder;
   NSString *newFolderName;
   struct MAPIStoreTallocWrapper *wrapper;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -836,7 +836,7 @@ sogo_folder_get_deleted_fmids(void *folder_object, TALLOC_CTX *mem_ctx,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -873,7 +873,7 @@ sogo_folder_open_table(void *folder_object, TALLOC_CTX *mem_ctx,
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -910,7 +910,7 @@ sogo_folder_modify_permissions(void *folder_object, uint8_t flags,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -942,7 +942,7 @@ sogo_folder_preload_message_bodies(void *folder_object, enum mapistore_table_typ
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreFolder *folder;
-  int rc;
+  enum mapistore_error rc;
 
   if (folder_object)
     {
@@ -975,7 +975,7 @@ sogo_message_get_message_data(void *message_object,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1008,7 +1008,7 @@ sogo_message_create_attachment (void *message_object, TALLOC_CTX *mem_ctx, void 
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
   MAPIStoreAttachment *attachment;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1042,7 +1042,7 @@ sogo_message_open_attachment (void *message_object, TALLOC_CTX *mem_ctx,
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
   MAPIStoreAttachment *attachment;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1075,7 +1075,7 @@ sogo_message_get_attachment_table (void *message_object, TALLOC_CTX *mem_ctx, vo
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
   MAPIStoreAttachmentTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1111,7 +1111,7 @@ sogo_message_modify_recipients (void *message_object,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1173,7 +1173,7 @@ sogo_message_save (void *message_object, TALLOC_CTX *mem_ctx)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1203,7 +1203,7 @@ sogo_message_submit (void *message_object, enum SubmitFlags flags)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreMailVolatileMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (message_object)
     {
@@ -1238,7 +1238,7 @@ sogo_message_attachment_open_embedded_message (void *attachment_object,
   NSAutoreleasePool *pool;
   MAPIStoreAttachment *attachment;
   MAPIStoreEmbeddedMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (attachment_object)
     {
@@ -1277,7 +1277,7 @@ sogo_message_attachment_create_embedded_message (void *attachment_object,
   NSAutoreleasePool *pool;
   MAPIStoreAttachment *attachment;
   MAPIStoreEmbeddedMessage *message;
-  int rc;
+  enum mapistore_error rc;
 
   if (attachment_object)
     {
@@ -1311,7 +1311,7 @@ static enum mapistore_error sogo_table_get_available_properties(void *table_obje
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1341,7 +1341,7 @@ sogo_table_set_columns (void *table_object, uint16_t count, enum MAPITAGS *prope
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1372,7 +1372,7 @@ sogo_table_set_restrictions (void *table_object, struct mapi_SRestriction *restr
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1405,7 +1405,7 @@ sogo_table_set_sort_order (void *table_object, struct SSortOrderSet *sort_order,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1440,7 +1440,7 @@ sogo_table_get_row (void *table_object, TALLOC_CTX *mem_ctx,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1473,7 +1473,7 @@ sogo_table_get_row_count (void *table_object,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1504,7 +1504,7 @@ sogo_table_handle_destructor (void *table_object, uint32_t handle_id)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreTable *table;
-  int rc;
+  enum mapistore_error rc;
 
   if (table_object)
     {
@@ -1536,7 +1536,7 @@ static enum mapistore_error sogo_properties_get_available_properties(void *objec
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreObject *propObject;
-  int rc;
+  enum mapistore_error rc;
 
   if (object)
     {
@@ -1569,7 +1569,7 @@ sogo_properties_get_properties (void *object,
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreObject *propObject;
-  int rc;
+  enum mapistore_error rc;
 
   if (object)
     {
@@ -1601,7 +1601,7 @@ sogo_properties_set_properties (void *object, struct SRow *aRow)
   struct MAPIStoreTallocWrapper *wrapper;
   NSAutoreleasePool *pool;
   MAPIStoreObject *propObject;
-  int rc;
+  enum mapistore_error rc;
 
   if (object)
     {
@@ -1679,10 +1679,10 @@ sogo_manager_generate_uri (TALLOC_CTX *mem_ctx,
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error
 */
-int mapistore_init_backend(void)
+enum mapistore_error mapistore_init_backend(void)
 {
   struct mapistore_backend backend;
-  int ret;
+  enum mapistore_error ret;
   static BOOL registered = NO;
 
   if (registered)

--- a/OpenChange/MAPIStoreSOGoObject.h
+++ b/OpenChange/MAPIStoreSOGoObject.h
@@ -65,18 +65,18 @@
 - (uint64_t) objectId;
 
 /* implemented getters */
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSearchKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagGenerateExchangeViews: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagParentSourceKey: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagSourceKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTagChangeKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSearchKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagGenerateExchangeViews: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagParentSourceKey: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagSourceKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTagChangeKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* subclasses */
 - (uint64_t) objectVersion;

--- a/OpenChange/MAPIStoreSOGoObject.m
+++ b/OpenChange/MAPIStoreSOGoObject.m
@@ -136,16 +136,16 @@ static Class MAPIStoreFolderK;
 }
 
 /* getters */
-- (int) getPidTagDisplayName: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagDisplayName: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [[sogoObject displayName] asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagSearchKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSearchKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *stringValue;
 
@@ -156,31 +156,31 @@ static Class MAPIStoreFolderK;
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagGenerateExchangeViews: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagGenerateExchangeViews: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagParentSourceKey: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagParentSourceKey: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getReplicaKey: data fromGlobCnt: [container objectId] >> 16
                     inMemCtx: memCtx];
 }
 
-- (int) getPidTagSourceKey: (void **) data
-              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagSourceKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getReplicaKey: data fromGlobCnt: [self objectId] >> 16
                     inMemCtx: memCtx];
 }
 
 /* helper getters */
-- (int) getPidTagChangeKey: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeKey: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   uint64_t obVersion;
 
   obVersion = [self objectVersion];
@@ -193,10 +193,10 @@ static Class MAPIStoreFolderK;
   return rc;
 }
 
-- (int) getPidTagChangeNumber: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagChangeNumber: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc;
+  enum mapistore_error rc;
   struct mapistore_connection_info *connInfo;
   uint64_t obVersion;
 

--- a/OpenChange/MAPIStoreSharingMessage.h
+++ b/OpenChange/MAPIStoreSharingMessage.h
@@ -1,6 +1,6 @@
 /* MAPIStoreSharingMessage.h - this file is part of SOGo-OpenChange
  *
- * Copyright (C) 2015 Enrique J. Hernández
+ * Copyright (C) 2015-2016 Enrique J. Hernández
  *
  * Author: Enrique J. Hernández <ejhernandez@zentyal.com>
  *
@@ -39,58 +39,58 @@
                fromMessage: (MAPIStoreMailMessage *) msg;
 
 /* getters */
-- (int) getPidLidSharingCapabilities: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingCapabilities: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingConfigurationUrl: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingConfigUrl: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingFlavor: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingFlavor: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingInitiatorEntryId: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingInitiatorName: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingInitiatorSmtp: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingLocalType: (void **) data
-                         inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingLocalType: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingProviderGuid: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingProviderGuid: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingProviderName: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingProviderName: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingProviderUrl: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingProviderUrl: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingRemoteName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingRemoteName: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingRemoteStoreUid: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameXSharingRemoteStoreUid: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingRemoteType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidTypeXSharingRemoteType: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingResponseTime: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidLidSharingResponseType: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getPidNameContentClass: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingCapabilities: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingCapabilities: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingConfigurationUrl: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingConfigUrl: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingFlavor: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingFlavor: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingInitiatorEntryId: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingInitiatorName: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingInitiatorSmtp: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingLocalType: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingLocalType: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingProviderGuid: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingProviderGuid: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingProviderName: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingProviderName: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingProviderUrl: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingProviderUrl: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingRemoteName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingRemoteName: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingRemoteStoreUid: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameXSharingRemoteStoreUid: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingRemoteType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidTypeXSharingRemoteType: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingResponseTime: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidLidSharingResponseType: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getPidNameContentClass: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* Save */
 - (void) saveWithMessage: (MAPIStoreMailMessage *) msg

--- a/OpenChange/MAPIStoreSharingMessage.m
+++ b/OpenChange/MAPIStoreSharingMessage.m
@@ -1,6 +1,6 @@
 /* MAPIStoreSharingMessage.m - this file is part of SOGo-OpenChange
  *
- * Copyright (C) 2015 Enrique J. Hernández
+ * Copyright (C) 2015-2016 Enrique J. Hernández
  *
  * Author: Enrique J. Hernández <ejhernandez@zentyal.com>
  *
@@ -108,8 +108,8 @@
 
 }
 
-- (int) getPidLidSharingCapabilities: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingCapabilities: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
 
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
@@ -125,8 +125,8 @@
   return rc;
 }
 
-- (int) getPidNameXSharingCapabilities: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingCapabilities: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
 
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
@@ -143,22 +143,22 @@
   return rc;
 }
 
-- (int) getPidLidSharingConfigurationUrl: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingConfigurationUrl: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
 
   *data = [@"" asUnicodeInMemCtx: memCtx];
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidNameXSharingConfigUrl: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingConfigUrl: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingConfigurationUrl: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingFlavor: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingFlavor: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* See [MS-OXSHARE] Section 2.2.2.5 for details */
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
@@ -206,8 +206,8 @@
   return rc;
 }
 
-- (int) getPidNameXSharingFlavor: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingFlavor: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   id value;
@@ -223,8 +223,8 @@
   return rc;
 }
 
-- (int) getPidLidSharingInitiatorEntryId: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingInitiatorEntryId: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   id value;
@@ -244,38 +244,38 @@
   return rc;
 }
 
-- (int) getPidLidSharingInitiatorName: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingInitiatorName: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-initiatorname"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingInitiatorSmtp: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingInitiatorSmtp: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-initiatorsmtp"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingLocalType: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingLocalType: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-localtype"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidNameXSharingLocalType: (void **) data
-                           inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingLocalType: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingLocalType: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingProviderGuid: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingProviderGuid: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   const unsigned char providerGuidBytes[] = {0xAE, 0xF0, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
                                              0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46};
@@ -284,15 +284,15 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidNameXSharingProviderGuid: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingProviderGuid: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"AEF0060000000000C000000000000046" asUnicodeInMemCtx: memCtx];
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidSharingProviderName: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingProviderName: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
 
   return [self _getStringProperty: @"x-ms-sharing-providername"
@@ -300,84 +300,84 @@
                          inMemCtx: memCtx];
 }
 
-- (int) getPidNameXSharingProviderName: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingProviderName: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingProviderName: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingProviderUrl: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingProviderUrl: (void **) data
+                                            inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-providerurl"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidNameXSharingProviderUrl: (void **) data
-                             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingProviderUrl: (void **) data
+                                              inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingProviderUrl: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingRemoteName: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingRemoteName: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-remotename"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidNameXSharingRemoteName: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingRemoteName: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingRemoteName: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingRemoteStoreUid: (void **) data
-                              inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingRemoteStoreUid: (void **) data
+                                               inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-remotestoreuid"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidNameXSharingRemoteStoreUid: (void **) data
-                                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameXSharingRemoteStoreUid: (void **) data
+                                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingRemoteStoreUid: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingRemoteType: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingRemoteType: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-remotetype"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidTypeXSharingRemoteType: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTypeXSharingRemoteType: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingRemoteType: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingRemoteUid: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingRemoteUid: (void **) data
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self _getStringProperty: @"x-ms-sharing-remoteuid"
                            inData: data
                          inMemCtx: memCtx];
 }
 
-- (int) getPidUidXSharingRemoteUid: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidUidXSharingRemoteUid: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidLidSharingRemoteUid: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidSharingResponseTime: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingResponseTime: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
   id value;
@@ -403,8 +403,8 @@
   return rc;
 }
 
-- (int) getPidLidSharingResponseType: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidSharingResponseType: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
 
   enum mapistore_error rc = MAPISTORE_ERR_NOT_FOUND;
@@ -423,8 +423,8 @@
   return rc;
 }
 
-- (int) getPidNameContentClass: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidNameContentClass: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = talloc_strdup (memCtx, "Sharing");
   return MAPISTORE_SUCCESS;

--- a/OpenChange/MAPIStoreTable.h
+++ b/OpenChange/MAPIStoreTable.h
@@ -88,17 +88,17 @@ typedef enum {
 
 - (void) cleanupCaches;
 
-- (int) getAvailableProperties: (struct SPropTagArray **) propertiesP
-                      inMemCtx: (TALLOC_CTX *) localMemCtx;
+- (enum mapistore_error) getAvailableProperties: (struct SPropTagArray **) propertiesP
+                                       inMemCtx: (TALLOC_CTX *) localMemCtx;
 - (void) setRestrictions: (const struct mapi_SRestriction *) res;
-- (int) setColumns: (enum MAPITAGS *) newColumns
-         withCount: (uint16_t) newColumCount;
-- (int) getRow: (struct mapistore_property_data **) dataP
-     withRowID: (uint32_t) rowId
-  andQueryType: (enum mapistore_query_type) queryType
-      inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getRowCount: (uint32_t *) countP
-      withQueryType: (enum mapistore_query_type) queryType;
+- (enum mapistore_error) setColumns: (enum MAPITAGS *) newColumns
+                          withCount: (uint16_t) newColumCount;
+- (enum mapistore_error) getRow: (struct mapistore_property_data **) dataP
+                      withRowID: (uint32_t) rowId
+                   andQueryType: (enum mapistore_query_type) queryType
+                       inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getRowCount: (uint32_t *) countP
+                       withQueryType: (enum mapistore_query_type) queryType;
 
 /* helpers */
 

--- a/OpenChange/MAPIStoreTable.m
+++ b/OpenChange/MAPIStoreTable.m
@@ -366,8 +366,8 @@ static Class NSDataK, NSStringK;
   currentRow = (uint32_t) -1;
 }
 
-- (int) getAvailableProperties: (struct SPropTagArray **) propertiesP
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getAvailableProperties: (struct SPropTagArray **) propertiesP
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [[isa childObjectClass] getAvailableProperties: propertiesP
                                                inMemCtx: memCtx];
@@ -749,8 +749,8 @@ static Class NSDataK, NSStringK;
 }
 
 /* proof of concept */
-- (int) setColumns: (enum MAPITAGS *) newColumns
-         withCount: (uint16_t) newColumnsCount
+- (enum mapistore_error) setColumns: (enum MAPITAGS *) newColumns
+                          withCount: (uint16_t) newColumnsCount
 {
   NSUInteger count;
 
@@ -831,15 +831,15 @@ static Class NSDataK, NSStringK;
   return nil;
 }
 
-- (int) getRow: (struct mapistore_property_data **) dataP
-     withRowID: (uint32_t) rowId
-  andQueryType: (enum mapistore_query_type) queryType
-      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getRow: (struct mapistore_property_data **) dataP
+                      withRowID: (uint32_t) rowId
+                   andQueryType: (enum mapistore_query_type) queryType
+                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSUInteger count;
   MAPIStoreObject *child;
   struct mapistore_property_data *rowData;
-  int rc;
+  enum mapistore_error rc;
 
   child = [self childAtRowID: rowId forQueryType: queryType];
   if (child)
@@ -858,8 +858,8 @@ static Class NSDataK, NSStringK;
   return rc;
 }
 
-- (int) getRowCount: (uint32_t *) countP
-      withQueryType: (enum mapistore_query_type) queryType
+- (enum mapistore_error) getRowCount: (uint32_t *) countP
+                       withQueryType: (enum mapistore_query_type) queryType
 {
   NSArray *children;
 

--- a/OpenChange/MAPIStoreTasksFolder.m
+++ b/OpenChange/MAPIStoreTasksFolder.m
@@ -128,7 +128,7 @@
             [(SOGoAppointmentFolder *) sogoObject aclSQLListingFilter]];
 }
 
-- (int) getPidTagDefaultPostMessageClass: (void **) data
+- (enum mapistore_error) getPidTagDefaultPostMessageClass: (void **) data
                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"IPM.Task" asUnicodeInMemCtx: memCtx];

--- a/OpenChange/MAPIStoreTasksMessage.m
+++ b/OpenChange/MAPIStoreTasksMessage.m
@@ -68,8 +68,8 @@
 
 @implementation MAPIStoreTasksMessage
 
-- (int) getPidTagIconIndex: (void **) data // TODO
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagIconIndex: (void **) data // TODO
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   /* see http://msdn.microsoft.com/en-us/library/cc815472.aspx */
   // Unassigned recurring task 0x00000501
@@ -83,16 +83,16 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagMessageClass: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageClass: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = talloc_strdup(memCtx, "IPM.Task");
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidTagNormalizedSubject: (void **) data // SUMMARY
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagNormalizedSubject: (void **) data // SUMMARY
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
   iCalToDo *task;
 
@@ -103,10 +103,10 @@
 }
 
 /* FIXME: Should be combined somehow with the code in MAPIStoreAppointmentWrapper.m */
-- (int) getPidTagBody: (void **) data
-             inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagBody: (void **) data
+                              inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSString *stringValue;
   iCalToDo *task;
   
@@ -122,8 +122,8 @@
 }
 
 /* FIXME: Should be combined somehow with the code in MAPIStoreAppointmentWrapper.m */
-- (int) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
-                inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPrivate: (void **) data // private (bool), should depend on CLASS and permissions
+                                 inMemCtx: (TALLOC_CTX *) memCtx
 {
   iCalToDo *task;
   
@@ -135,8 +135,8 @@
   return [self getYes: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagImportance: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagImportance: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint32_t v;
   iCalToDo *task;
@@ -154,8 +154,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidTaskComplete: (void **) data
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskComplete: (void **) data
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   iCalToDo *task;
 
@@ -166,8 +166,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidPercentComplete: (void **) data
-                        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidPercentComplete: (void **) data
+                                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   double doubleValue;
   iCalToDo *task;
@@ -180,10 +180,10 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidTaskDateCompleted: (void **) data
-                          inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskDateCompleted: (void **) data
+                                           inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSCalendarDate *dateValue;
   iCalToDo *task;
 
@@ -198,54 +198,54 @@
   return rc;
 }
 
-- (int) getPidLidTaskState: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskState: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0x1); // not assigned
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidTaskMode: (void **) data // TODO
-                 inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskMode: (void **) data // TODO
+                                  inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskFRecurring: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskFRecurring: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskAccepted: (void **) data // TODO
-                     inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskAccepted: (void **) data // TODO
+                                      inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskActualEffort: (void **) data // TODO
-                         inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskActualEffort: (void **) data // TODO
+                                          inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskEstimatedEffort: (void **) data // TODO
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskEstimatedEffort: (void **) data // TODO
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }
 
-- (int) getPidTagHasAttachments: (void **) data
-                       inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagHasAttachments: (void **) data
+                                        inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getNo: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskDueDate: (void **) data
-                    inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskDueDate: (void **) data
+                                     inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSCalendarDate *dateValue;
   iCalToDo *task;
 
@@ -259,10 +259,10 @@
   return rc;
 }
 
-- (int) getPidLidTaskStartDate: (void **) data
-		      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskStartDate: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
   NSCalendarDate *dateValue;
   iCalToDo *task;
 
@@ -277,26 +277,26 @@
 }
 
 
-- (int) getPidTagMessageDeliveryTime: (void **) data
-                            inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidTagMessageDeliveryTime: (void **) data
+                                             inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagLastModificationTime: data inMemCtx: memCtx];
 }
 
-- (int) getClientSubmitTime: (void **) data
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getClientSubmitTime: (void **) data
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagLastModificationTime: data inMemCtx: memCtx];
 }
 
-- (int) getLocalCommitTime: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getLocalCommitTime: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getPidTagLastModificationTime: data inMemCtx: memCtx];
 }
 
-- (int) getPidLidTaskStatus: (void **) data // status
-                   inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskStatus: (void **) data // status
+                                    inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *status;
   uint32_t longValue;
@@ -318,8 +318,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidTaskOwner: (void **) data
-                  inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskOwner: (void **) data
+                                   inMemCtx: (TALLOC_CTX *) memCtx
 {
   NSString *owner;
 
@@ -330,8 +330,8 @@
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getPidLidTaskOwnership: (void **) data
-                      inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getPidLidTaskOwnership: (void **) data
+                                       inMemCtx: (TALLOC_CTX *) memCtx
 {
   return [self getLongZero: data inMemCtx: memCtx];
 }

--- a/OpenChange/NSObject+MAPIStore.h
+++ b/OpenChange/NSObject+MAPIStore.h
@@ -41,16 +41,16 @@ struct MAPIStoreTallocWrapper
 
 @interface NSObject (MAPIStoreDataTypes)
 
-- (int) getValue: (void **) data
-          forTag: (enum MAPITAGS) propTag
-        inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getValue: (void **) data
+                           forTag: (enum MAPITAGS) propTag
+                         inMemCtx: (TALLOC_CTX *) memCtx;
 
 /* getter helpers */
-- (int) getEmptyString: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getLongZero: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getYes: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getNo: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
-- (int) getSMTPAddrType: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getEmptyString: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getLongZero: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getYes: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getNo: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
+- (enum mapistore_error) getSMTPAddrType: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;
 
 @end
 

--- a/OpenChange/NSObject+MAPIStore.m
+++ b/OpenChange/NSObject+MAPIStore.m
@@ -74,12 +74,12 @@ MAPIStoreTallocWrapperDestroy (void *data)
 
 @implementation NSObject (MAPIStoreDataTypes)
 
-- (int) getValue: (void **) data
-          forTag: (enum MAPITAGS) propTag
-        inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getValue: (void **) data
+                           forTag: (enum MAPITAGS) propTag
+                         inMemCtx: (TALLOC_CTX *) memCtx
 {
   uint16_t valueType;
-  int rc = MAPISTORE_SUCCESS;
+  enum mapistore_error rc = MAPISTORE_SUCCESS;
 
   // [self logWithFormat: @"property %.8x found", propTag];
   valueType = (propTag & 0xffff);
@@ -139,35 +139,35 @@ MAPIStoreTallocWrapperDestroy (void *data)
 }
 
 /* helper getters */
-- (int) getEmptyString: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getEmptyString: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"" asUnicodeInMemCtx: memCtx];
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getLongZero: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getLongZero: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPILongValue (memCtx, 0);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getYes: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getYes: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, YES);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getNo: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getNo: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = MAPIBoolValue (memCtx, NO);
 
   return MAPISTORE_SUCCESS;
 }
 
-- (int) getSMTPAddrType: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
+- (enum mapistore_error) getSMTPAddrType: (void **) data inMemCtx: (TALLOC_CTX *) memCtx
 {
   *data = [@"SMTP" asUnicodeInMemCtx: memCtx];
 

--- a/OpenChange/code-MAPIStorePropertySelectors.h
+++ b/OpenChange/code-MAPIStorePropertySelectors.h
@@ -20,8 +20,8 @@
  * Boston, MA 02111-1307, USA.
  */
 
-typedef int (*MAPIStorePropertyGetter) (id inst, SEL _cmd,
-                                        void **data, TALLOC_CTX *memCtx);
+typedef enum mapistore_error (*MAPIStorePropertyGetter) (id inst, SEL _cmd,
+                                                         void **data, TALLOC_CTX *memCtx);
 
 const MAPIStorePropertyGetter *MAPIStorePropertyGettersForClass (Class klass);
 SEL MAPIStoreSelectorForPropertyGetter (uint16_t propertyId);

--- a/OpenChange/gen-property-selectors.py
+++ b/OpenChange/gen-property-selectors.py
@@ -235,7 +235,7 @@ if __name__ == "__main__":
             highest_prop_idx = prop_idx
         getters.append("  @selector (get%s:inMemCtx:)" % name)
         # preferred_types.append("  0x%.4x" % (prop_tag & 0xffff))
-        prototypes.append("- (int) get%s: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;" % name)
+        prototypes.append("- (enum mapistore_error) get%s: (void **) data inMemCtx: (TALLOC_CTX *) memCtx;" % name)
         current_getter_idx = current_getter_idx + 1
         # setters[prop_idx] = "  @selector (set%s:)" % name
         # prototypes.append("- (int) set%s: (void **) data;" % name)


### PR DESCRIPTION
This specifies a little the scope of the variable to make it
more realistic with the actual values it may have. We do have
a static typed compiled language, why don't we use it?