### PR TITLE
Free objects used only to generate body content data

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.m
+++ b/OpenChange/MAPIStoreMailMessage.m
@@ -537,6 +537,17 @@ _compareBodyKeysByPriority (id entry1, id entry2, void *data)
     }
 
   bodySetup = YES;
+  /* Free data from header setup that it is only used for setup the body */
+  [bodyContentKeys release];
+  bodyContentKeys = nil;  
+  [bodyPartsEncodings release];
+  bodyPartsEncodings = nil;  
+  [bodyPartsCharsets release];
+  bodyPartsCharsets = nil;
+  [bodyPartsMimeTypes release];
+  bodyPartsMimeTypes = nil;  
+  [bodyPartsMixed release];
+  bodyPartsMixed = nil;  
 }
 
 - (NSArray*) getBodyContent


### PR DESCRIPTION
Once the body content data is generated they are not longer needed.
So in place of awaiting the destruction of the mail object, we
release them when the dody is generated. This way the peak memory
is reduced.
