### PR TITLE
Use enumerator type instead of full string to identify MIME types

### DIFF
--- a/OpenChange/MAPIStoreMailMessage.h
+++ b/OpenChange/MAPIStoreMailMessage.h
@@ -33,6 +33,14 @@
 @class MAPIStoreAppointmentWrapper;
 @class MAPIStoreMailFolder;
 
+enum MIME_TYPE {
+  NONE_MIME_TYPE,
+  TEXT_CALENDAR,
+  APPLICATION_ICS,
+  TEXT_HTML,
+  TEXT_PLAIN
+};
+
 @interface MAPIStoreMailMessage : MAPIStoreMessage
 {
   BOOL headerSetup;
@@ -47,7 +55,7 @@
   NSMutableDictionary *bodyPartsMixed;
   
   NSString *headerCharset;
-  NSString *headerMimeType;
+  enum MIME_TYPE headerMimeType;
   BOOL bodySetup;
   NSArray *bodyContent;
   BOOL fetchedAttachments;


### PR DESCRIPTION
Instead of using the full string for the MIME type of the message
and the parts, we assign it a enum value after parsing it.

This replaces string operations for integer operations.
Also makes easier to add equivalent MIME types just assigning them
the same identifier.
